### PR TITLE
Make blend weight adjustment conditional via AdjustBlendWeights profi…

### DIFF
--- a/MMLaunch/ModUtil.fs
+++ b/MMLaunch/ModUtil.fs
@@ -193,6 +193,7 @@ module ModUtil =
         VertDeclPath: string
         ExpectedPrimCount: int
         ExpectedVertCount: int
+        Profile: ModelMod.CoreTypes.SnapProfile
     }
 
     type YamlMod = {
@@ -351,8 +352,19 @@ mods:"""
                 File.Copy(refMMObjFile,modMMObjFile)
                 modMMObjFile
 
+            // look for a snapshot meta file which may contain information about what profile was used
+            let metaFile = Path.Combine(snapSrcDir, srcBasename + "_Meta.yaml")
+            let snapProfile =
+                if File.Exists(metaFile) then
+                    let sd = new Deserializer()
+                    use f = File.OpenText(metaFile);
+                    let p = sd.Deserialize<ModelMod.Snapshot.SnapMeta>(f)
+                    p.Profile
+                else
+                    ModelMod.SnapshotProfile.EmptyProfile
+
             // generate ref yaml
-            let refYamlFile = 
+            let refYamlFile =
                 let refYamlFile = Path.Combine(modOutDir, refBasename + ".yaml")
                 let refObj = {
                     YamlRef.Type = "Reference"
@@ -360,22 +372,12 @@ mods:"""
                     YamlRef.VertDeclPath = if vbDeclFile <> "" then Path.GetFileName(vbDeclFile) else ""
                     YamlRef.ExpectedPrimCount = pCount
                     YamlRef.ExpectedVertCount = vCount
+                    YamlRef.Profile = snapProfile
                 }
                 let sr = new Serializer()
                 use sw = new StreamWriter(refYamlFile)
-                sr.Serialize(sw, refObj) 
+                sr.Serialize(sw, refObj)
                 refYamlFile
-
-            // look for a snapshot meta file which may contain information about what profile was used
-            let metaFile = Path.Combine(snapSrcDir, srcBasename + "_Meta.yaml")
-            let snapProfile = 
-                if File.Exists(metaFile) then 
-                    let sd = new Deserializer()
-                    use f = File.OpenText(metaFile);
-                    let p = sd.Deserialize<ModelMod.Snapshot.SnapMeta>(f)
-                    p.Profile
-                else 
-                    ModelMod.SnapshotProfile.EmptyProfile
 
             // generate mod yaml 
             let modYamlFile = 

--- a/MMLaunch/PreviewHost.fs
+++ b/MMLaunch/PreviewHost.fs
@@ -45,7 +45,7 @@ type PreviewHost() =
                     Some({
                             Window = None
                             CamPosition = Some(Vec3F(0.f,3.75f,10.0f))
-                            MeshReadFlags = { ReadMaterialFile = true; ReverseTransform = false }
+                            MeshReadFlags = { ReadMaterialFile = true; ReverseTransform = false; AdjustBlendWeights = AdjustBlendWeightsDefault }
                     })
                 Conf.BinCacheDir = ""
             }

--- a/MMManaged/CoreTypes.fs
+++ b/MMManaged/CoreTypes.fs
@@ -211,12 +211,20 @@ module CoreTypes =
         /// happens.  It can be useful to turn it off in tools, so that the mod is displayed in post-snapshot
         /// space (the same view that the tool will see).  The launcher preview window, for instance, turns this off.
         ReverseTransform: bool
+        /// Controls whether blend weights are adjusted to sum to 1.0 on load.
+        /// AdjustBlendWeightsDefault or empty string applies the adjustment (adds deficit to X component).
+        /// Any other value leaves weights as-is.
+        AdjustBlendWeights: string
     }
+
+    /// Value for AdjustBlendWeights that applies the blend weight sum-to-1.0 fix (adds deficit to X component).
+    let AdjustBlendWeightsDefault = "addx"
 
     /// Default read flags; used when no overriding flags are specified.
     let DefaultReadFlags = {
         ReadMaterialFile = false
         ReverseTransform = true
+        AdjustBlendWeights = AdjustBlendWeightsDefault
     }
 
     /// A snapshot profile controls what types of data transformations
@@ -234,6 +242,7 @@ module CoreTypes =
         let mutable vecEncoding:string = "";
         let mutable blendIndexInColor1:bool = false;
         let mutable blendWeightInColor2:bool = false;
+        let mutable adjustBlendWeights:string = AdjustBlendWeightsDefault;
 
         static member Create(name,posX,uvX,flipTangent,vecEncoding:string,blendIndexInColor1:bool,blendWeightInColor2:bool):SnapProfile =
             let p = new SnapProfile()
@@ -253,12 +262,13 @@ module CoreTypes =
         member x.VecEncoding with get() = vecEncoding and set v = vecEncoding <- v
         member x.BlendIndexInColor1 with get() = blendIndexInColor1 and set v = blendIndexInColor1 <- v
         member x.BlendWeightInColor2 with get() = blendWeightInColor2 and set v = blendWeightInColor2 <- v
+        member x.AdjustBlendWeights with get() = adjustBlendWeights and set v = adjustBlendWeights <- v
 
         member x.IsPackedVec() = vecEncoding.Trim().ToLowerInvariant() = "packed"
         member x.IsOctaVec() = vecEncoding.Trim().ToLowerInvariant() = "octa"
 
         override x.ToString() =
-            sprintf "[SnapshotProfile: %s; pos: %A; uv: %A, fliptangent: %A, vecencoding: %A, blendindexincolor1: %A, blendweightincolor2: %A]" name posX uvX flipTangent vecEncoding blendIndexInColor1 blendWeightInColor2
+            sprintf "[SnapshotProfile: %s; pos: %A; uv: %A, fliptangent: %A, vecencoding: %A, blendindexincolor1: %A, blendweightincolor2: %A, adjustblendweights: %A]" name posX uvX flipTangent vecEncoding blendIndexInColor1 blendWeightInColor2 adjustBlendWeights
 
     /// Basic storage for everything that we consider to be "mesh data".  This is intentionally pretty close to the
     /// renderer level; i.e. we don't have fields like "NormalMap" because the texture stage used for will vary

--- a/MMManaged/MeshUtil.fs
+++ b/MMManaged/MeshUtil.fs
@@ -125,20 +125,27 @@ module MeshUtil =
                 Some( [| {Pos=v.[0]; Tex=v.[1]; Nrm=v.[2]}; {Pos=v.[3]; Tex=v.[4]; Nrm=v.[5]}; {Pos=v.[6]; Tex=v.[7]; Nrm=v.[8]} |] )
             | _ -> None
 
+        let shouldAdjustBlendWeights =
+            let abw = flags.AdjustBlendWeights.Trim().ToLowerInvariant()
+            abw = "" || abw = AdjustBlendWeightsDefault
+
         let makeBlendVectors (components:(int32 * float32)[] option) =
             match components with
             | Some v when v.Length = 4 ->
                 let indices = new Vec4X(fst v.[0], fst v.[1], fst v.[2], fst v.[3])
                 let weights = new Vec4F(snd v.[0], snd v.[1], snd v.[2], snd v.[3])
 
-                // TODO: hack fix: the weights MUST sum to 1.0, or else bad shit happens in game.
-                // I think I have some bad rounding going on somewhere
-                // in the conversion/capture of these; either in snapshotting, or in blender,
-                // since the differences are small.
-                let sum = weights.X + weights.Y + weights.Z + weights.W
                 let weights =
-                    if ((1.f - sum) > 0.f) then
-                        new Vec4F(weights.X + (1.f - sum), weights.Y, weights.Z, weights.W)
+                    if shouldAdjustBlendWeights then
+                        // hack fix: the weights MUST sum to 1.0, or else bad shit happens in game.
+                        // I think I have some bad rounding going on somewhere
+                        // in the conversion/capture of these; either in snapshotting, or in blender,
+                        // since the differences are small.
+                        let sum = weights.X + weights.Y + weights.Z + weights.W
+                        if ((1.f - sum) > 0.f) then
+                            new Vec4F(weights.X + (1.f - sum), weights.Y, weights.Z, weights.W)
+                        else
+                            weights
                     else
                         weights
 

--- a/MMManaged/ModDB.fs
+++ b/MMManaged/ModDB.fs
@@ -218,9 +218,17 @@ module ModDB =
 
         let pixelShader = node |> Yaml.getOptionalValue "pixelshader" |> unpackPath
 
+        // load profile early so it can influence mesh read flags
+        let profile =
+            match node |> Yaml.getOptionalValue "Profile" |> Yaml.toOptionalMapping with
+            | Some(profile) -> Some(loadSingleProfile "" profile)
+            | None -> None
+
         let mutable numOverrideTextures = 0
         let mutable fullMeshPath = ""
-        let meshReadFlags = CoreTypes.DefaultReadFlags
+        let meshReadFlags =
+            let abw = match profile with Some(p) -> p.AdjustBlendWeights | None -> AdjustBlendWeightsDefault
+            { CoreTypes.DefaultReadFlags with AdjustBlendWeights = abw }
         let mesh,modType,weightMode,attrs =
             let sType = (node |> Yaml.getFirstValue ["modtype"; "meshtype"] |> Yaml.toString).ToLower().Trim()
             let modType = getModType sType
@@ -309,12 +317,6 @@ module ModDB =
         let parentModName = node |> Yaml.getOptionalValue "ParentModName" |> Yaml.toOptionalString
 
         let computeTS = node |> Yaml.getOptionalValue "UpdateTangentSpace" |> Yaml.toOptionalBool
-
-        // has a profile?
-        let profile = 
-            match node |> Yaml.getOptionalValue "Profile" |> Yaml.toOptionalMapping with 
-            | Some(profile) -> Some(loadSingleProfile "" profile)
-            | None -> None
 
         let md = {
             DBMod.RefName = refName
@@ -417,8 +419,15 @@ module ModDB =
             | Some(path) -> path
             | None -> meshFullPath
 
-        let meshReadFlags = CoreTypes.DefaultReadFlags
-        let doMeshLoad() = 
+        let profile =
+            match node |> Yaml.getOptionalValue "Profile" |> Yaml.toOptionalMapping with
+            | Some(profile) -> Some(loadSingleProfile "" profile)
+            | None -> None
+
+        let meshReadFlags =
+            let abw = match profile with Some(p) -> p.AdjustBlendWeights | None -> AdjustBlendWeightsDefault
+            { CoreTypes.DefaultReadFlags with AdjustBlendWeights = abw }
+        let doMeshLoad() =
             let mesh = loadMesh (meshFullPath,ModType.Reference,meshReadFlags)
 
             // load vertex elements (binary)

--- a/MMManaged/SnapshotProfile.fs
+++ b/MMManaged/SnapshotProfile.fs
@@ -44,9 +44,13 @@ module SnapshotProfile =
         let blendIndexInColor1 = values |> Yaml.getOptionalBool "BlendIndexInColor1" |> Option.defaultValue false
         let blendWeightInColor2 = values |> Yaml.getOptionalBool "BlendWeightInColor2" |> Option.defaultValue false
 
+        let adjustBlendWeights = values |> Yaml.getOptionalString "AdjustBlendWeights" |> Option.defaultValue AdjustBlendWeightsDefault
+
         let pname = values |> Yaml.getOptionalString "Name" |> Option.defaultValue name
 
-        SnapProfile.Create(pname,posX,uvX,flipTang,vecEncoding,blendIndexInColor1,blendWeightInColor2)
+        let p = SnapProfile.Create(pname,posX,uvX,flipTang,vecEncoding,blendIndexInColor1,blendWeightInColor2)
+        p.AdjustBlendWeights <- adjustBlendWeights
+        p
 
     let toInteropStruct (profile: CoreTypes.SnapProfile): InteropTypes.ModSnapProfile =
         // Constants for field size limits

--- a/MMView/Main.fs
+++ b/MMView/Main.fs
@@ -255,7 +255,7 @@ module Main =
                 ({ 
                     AppSettings.Window = winSettings
                     CamPosition = camPos 
-                    MeshReadFlags = { ReadMaterialFile = true; ReverseTransform = transform }
+                    MeshReadFlags = { ReadMaterialFile = true; ReverseTransform = transform; AdjustBlendWeights = AdjustBlendWeightsDefault }
                 })
     
     let run(argv:string[]) =


### PR DESCRIPTION
…le field

The makeBlendVectors hack fix (adding weight deficit to X component when blend weights don't sum to 1.0) can produce incorrect results in some cases. Add AdjustBlendWeights string field to SnapProfile and MeshReadFlags so the fix can be controlled per-mod.

When set to "addx" (the default), the existing adjustment is applied. Any other non-empty value (e.g. "none") leaves blend weights as-is. The default is "addx" everywhere - including when no profile is present or the field is not specified - preserving backwards compatibility with existing mods.

Changes:
- CoreTypes: Add AdjustBlendWeightsDefault constant, AdjustBlendWeights field to SnapProfile and MeshReadFlags
- SnapshotProfile: Read AdjustBlendWeights in loadSingleProfile
- MeshUtil: Make blend weight adjustment conditional in makeBlendVectors
- ModDB: Load profile before mesh reading in buildMod and buildReference so the flag flows through MeshReadFlags to readObj
- ModUtil: Include profile in reference YAML (previously only in mod YAML); move snapshot meta loading earlier in createMod so profile is available for both ref and mod YAML generation
- PreviewHost, MMView: Update explicit MeshReadFlags construction

https://claude.ai/code/session_01EaYpUxG3E18KFN7Z8YN1mL