### PR TITLE
Move BinCache from Temp to LocalAppData

### DIFF
--- a/MMManaged/ModDBInterop.fs
+++ b/MMManaged/ModDBInterop.fs
@@ -132,7 +132,7 @@ module ModDBInterop =
             if not (File.Exists(modIndexPath)) then
                 failwithf "Cannot load data, index file does not exist: %A" modIndexPath
 
-            let binCacheDir = Path.Combine(Path.GetTempPath(), "ModelMod", "BinCache", State.getExeBaseName())
+            let binCacheDir = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "ModelMod", "BinCache", State.getExeBaseName())
             let conf = {
                 StartConf.Conf.ModIndexFile = Some modIndexPath
                 StartConf.Conf.FilesToLoad = []

--- a/MMManaged/Program.fs
+++ b/MMManaged/Program.fs
@@ -43,7 +43,7 @@ let load() =
                 StartConf.Conf.ModIndexFile = Some(mpath)
                 FilesToLoad = []
                 AppSettings = None
-                StartConf.Conf.BinCacheDir = Path.Combine(Path.GetTempPath(), "ModelMod", "BinCache", "standalone")
+                StartConf.Conf.BinCacheDir = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "ModelMod", "BinCache", "standalone")
             }, None)
     mdb
 

--- a/MMView/Main.fs
+++ b/MMView/Main.fs
@@ -286,7 +286,7 @@ module Main =
                     ModIndexFile = None
                     StartConf.Conf.FilesToLoad = [ file ] 
                     AppSettings = appSettings
-                    StartConf.Conf.BinCacheDir = Path.Combine(Path.GetTempPath(), "ModelMod", "BinCache", "mmview")
+                    StartConf.Conf.BinCacheDir = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "ModelMod", "BinCache", "mmview")
                 }
             | Some file when Path.GetExtension(file).ToLowerInvariant().Trim().Equals(".yaml") ->
                 // alternate conf file path

--- a/Test.MMManaged/TestModDB.fs
+++ b/Test.MMManaged/TestModDB.fs
@@ -16,7 +16,7 @@ let ``ModDB: load mod db``() =
                 StartConf.Conf.ModIndexFile = Some(mpath)
                 FilesToLoad = []
                 AppSettings = None
-                StartConf.Conf.BinCacheDir = Path.Combine(Path.GetTempPath(), "ModelMod", "BinCache", "tests")
+                StartConf.Conf.BinCacheDir = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), "ModelMod", "BinCache", "tests")
             }, None)
 
     Assert.AreEqual (mdb.Mods.Length, 2, sprintf "incorrect number of mods: %A" mdb.Mods)


### PR DESCRIPTION
Cache files in %TEMP%\ModelMod\BinCache were getting cleared by Windows more often than expected. Move them to %LOCALAPPDATA%\ModelMod\BinCache where they will persist properly.

https://claude.ai/code/session_01GaHLnfo1Yykw7weBvPa6xG