### PR TITLE
Add CLAUDE.md with Rust cross-compilation instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# ModelMod - Claude Code Notes
+
+## Rust Build
+
+This is a Windows-only project, but cross-compilation works from Linux.
+
+- Workspace root: `Native/`
+- To check Rust code compiles: `cd Native && cargo check --target x86_64-pc-windows-msvc`
+- Always use `--target x86_64-pc-windows-msvc` — without it, cargo will target Linux and fail
+- Runtime tests (`cargo test`) won't work on Linux since they call Windows APIs, but compilation checks are valid


### PR DESCRIPTION
Documents that cargo check needs --target x86_64-pc-windows-msvc to work correctly on Linux for this Windows-only project.

https://claude.ai/code/session_01V7iwfRoqPX5V1J3zTQ5LQk