### PR TITLE
Fix thread-safety race condition in MemoryCache causing NullReference…

### DIFF
--- a/MMManaged/MemoryCache.fs
+++ b/MMManaged/MemoryCache.fs
@@ -22,6 +22,7 @@ open CoreTypes
 open InteropTypes
 
 open System.Collections.Generic
+open System.Collections.Concurrent
 
 /// This is a simple in-memory cache for loaded meshes.  It speeds up reload iteration time,
 /// since only modified meshes are reloaded.  Would be nice to extend this to other things
@@ -38,7 +39,7 @@ module MemoryCache =
         MTime:System.DateTime
     }
 
-    let cache = new Dictionary<string,CacheEntry>()
+    let cache = new ConcurrentDictionary<string,CacheEntry>()
 
     let clear() = cache.Clear()
 


### PR DESCRIPTION
…Exception

Replace Dictionary with ConcurrentDictionary in MemoryCache to fix intermittent NullReferenceException during initial mesh loading. Multiple threads spawned by ModDBInterop.loadit could concurrently write to the non-thread-safe Dictionary, corrupting its internal data structures.

https://claude.ai/code/session_01Gxj8dbG6VZJzie1DbsRf8Q