### PR TITLE
Clean up dx9 snapshot candidate textures more aggressively

### DIFF
--- a/Native/hook_core/src/hook_device.rs
+++ b/Native/hook_core/src/hook_device.rs
@@ -7,6 +7,7 @@ pub use winapi::shared::winerror::{E_FAIL, S_OK};
 pub use winapi::um::winnt::{HRESULT, LPCWSTR};
 use std;
 use std::ptr::null_mut;
+use std::time::Instant;
 use shared_dx::types::*;
 use shared_dx::types_dx9::*;
 use shared_dx::util::*;
@@ -277,8 +278,11 @@ unsafe extern "system" fn hook_update_texture(
 /// is ordered oldest-first, so nothing behind is due either).
 pub unsafe fn dx9_update_texture_gc() {
     use std::time::Duration;
-    const AGE_THRESHOLD: Duration = Duration::from_secs(600); // 10 minutes
-    const MAX_PER_PASS: usize = 100;
+    const AGE_THRESHOLD: Duration = Duration::from_mins(5);
+    const MAX_PER_PASS: usize = 1000;
+    const MAX_TIME_PER_PASS_MICROS:u128 = 10000;
+
+    let start = Instant::now();
 
     let deque_len = GLOBAL_STATE.dx9_update_texture_deque.as_ref()
         .map(|d| d.len())
@@ -292,7 +296,13 @@ pub unsafe fn dx9_update_texture_gc() {
     let mut processed: usize = 0;
     let mut refreshed: usize = 0;
 
-    for _ in 0..count {
+    for i in 0..count {
+        if i % 50 == 0 {
+            // check to see if we ran out of time
+            if Instant::now().duration_since(start).as_micros() > MAX_TIME_PER_PASS_MICROS {
+                break;
+            }
+        }
         // Peek front; if not old enough, stop the whole pass.
         let front_due = GLOBAL_STATE.dx9_update_texture_deque.as_ref()
             .and_then(|d| d.front().copied())
@@ -336,11 +346,12 @@ pub unsafe fn dx9_update_texture_gc() {
 
     if processed > 0 {
         write_log_file(&format!(
-            "dx9_update_texture_gc: processed {} (refreshed {}, released {}), deque now {}",
+            "dx9_update_texture_gc: processed {} (refreshed {}, released {}), deque now {}; elapsed: {}micros",
             processed,
             refreshed,
             released_srcs.len(),
-            GLOBAL_STATE.dx9_update_texture_deque.as_ref().map(|d| d.len()).unwrap_or(0)
+            GLOBAL_STATE.dx9_update_texture_deque.as_ref().map(|d| d.len()).unwrap_or(0),
+            Instant::now().duration_since(start).as_micros()
         ));
     }
 }


### PR DESCRIPTION
- New GC was far too weak, memory usage was accumulating (gigabytes), so need to do more per pass.
- However dropping these textures is definitely not free (routinely single digit MS and often more), so limit it to max of 10ms to reduce pauses (still a lot more than i'd like but if I don't allow at least that much time the accumulation is still too much)
- I plan to gate this whole thing behind a game profile setting so that games that don't need this (every dx9 game before now) aren't encumbered.  may also experiment with multithreaded drops (though I think the d3d9 device still has to lock internally on each release in that case which would also affect perf).  or I should just hook all texture release and skip needing to do a GC pass