### PR TITLE
Set dx9 tex snap mode based on GameProfile

### DIFF
--- a/MMManaged/RegConfig.fs
+++ b/MMManaged/RegConfig.fs
@@ -76,6 +76,9 @@ module RegUtil =
             sw.ToString()
 
 /// Utilities for accessing ModelMod specific configuration data.
+///
+/// Note the GameProfile portion of this also now has an implementation in the rust code (util::GameProfile) which 
+/// provides read-only access to profile values.
 module RegConfig =
     let private log = Logging.getLogger("RegConfig")
 

--- a/Native/Cargo.lock
+++ b/Native/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "shared_dx",
  "snaplib",
  "types",
+ "util",
  "winapi",
 ]
 

--- a/Native/d3dx/src/d3dx.rs
+++ b/Native/d3dx/src/d3dx.rs
@@ -250,7 +250,7 @@ pub unsafe fn save_texture(idx: i32, path: *const u16) -> Result<()> {
             }
 
             // If this destination texture has a known source (tracked by the
-            // UpdateTexture hook), use the source instead. Games commonly create
+            // UpdateTexture hook), use the source instead. At least one dx9 game creates
             // the source in SYSTEMMEM (lockable) and the destination in DEFAULT
             // (not lockable), so the destination can't be saved directly.
             // The source is kept alive by an AddRef in hook_update_texture;

--- a/Native/global_state/Cargo.toml
+++ b/Native/global_state/Cargo.toml
@@ -19,3 +19,4 @@ input = { path = "../input" }
 constant_tracking = { path = "../constant_tracking" }
 snaplib = { path = "../snaplib" }
 shared_dx = { path = "../shared_dx" }
+util = { path = "../util" }

--- a/Native/global_state/src/global_state.rs
+++ b/Native/global_state/src/global_state.rs
@@ -2,6 +2,7 @@
 use shared_dx::types::DevicePointer;
 use shared_dx::util::write_log_file;
 use types::TexPtr;
+use util::game_profile::EMPTY_GAME_PROFILE;
 pub use winapi::shared::d3d9::*;
 pub use winapi::shared::d3d9types::*;
 pub use winapi::shared::minwindef::*;
@@ -23,6 +24,7 @@ use types::native_mod;
 use types::d3dx;
 
 use snaplib::anim_snap_state::AnimSnapState;
+use util::game_profile::GameProfile;
 
 pub const MAX_STAGE: usize = 40;
 
@@ -78,11 +80,9 @@ pub struct ClrState {
 pub struct RunConf {
     pub precopy_data: bool,
     pub force_tex_cpu_read: bool,
-    /// Registry path of the matched game profile (e.g.
-    /// `Software\ModelMod\Profiles\Profile0000`), or empty if none was found.
-    /// Populated at device-creation time by the early profile lookup in
-    /// `util::game_profile`.
-    pub profile_key: String,
+    /// Game profile data loaded from the profile found for this registry key
+    /// (example: `Software\ModelMod\Profiles\Profile0000`), or empty if none was found.
+    pub profile: GameProfile,
 }
 pub struct HookState {
     pub run_conf: RunConf,
@@ -172,7 +172,7 @@ pub static mut GLOBAL_STATE: HookState = HookState {
     run_conf: RunConf {
         precopy_data: false,
         force_tex_cpu_read: false,
-        profile_key: String::new(),
+        profile: EMPTY_GAME_PROFILE,
     },
     clr: { ClrState { runtime_pointer: None, run_context: String::new() } },
     interop_state: None,

--- a/Native/hook_core/src/hook_device.rs
+++ b/Native/hook_core/src/hook_device.rs
@@ -94,10 +94,14 @@ unsafe fn hook_d3d9_device(
     // The way to tell if this pool-flip 
     // method is sufficient is enable the reg key and load the game - 
     // if everything shows up black, this method is not sufficient.
+    // For games of that type, snap_use_sysmemtexturetracking below might be what is needed.
     (*vtbl).CreateTexture = hook_create_texture;
-    // Always hook UpdateTexture to track source->destination mappings so that
-    // during snapshotting we can reach back to the lockable source texture.
-    (*vtbl).UpdateTexture = hook_update_texture;
+
+    if GLOBAL_STATE.run_conf.profile.snap_use_sysmemtexturetracking {
+        // hook UpdateTexture to track source->destination mappings so that
+        // during snapshotting we can reach back to the lockable source texture.
+        (*vtbl).UpdateTexture = hook_update_texture;
+    }
 
     protect_memory(vtbl as *mut c_void, vsize, old_prot)?;
 

--- a/Native/hook_core/src/hook_device_d3d11.rs
+++ b/Native/hook_core/src/hook_device_d3d11.rs
@@ -690,10 +690,10 @@ pub unsafe fn query_and_set_runconf_in_globalstate(check_precopy:bool) -> bool {
 
     // Look up the game profile for the current exe so that profile settings
     // are available before hooks are installed.
-    if GLOBAL_STATE.run_conf.profile_key.is_empty() {
+    if GLOBAL_STATE.run_conf.profile.profile_key.is_empty() {
         let profile = util::game_profile::load_for_current_exe();
         if !profile.profile_key.is_empty() {
-            GLOBAL_STATE.run_conf.profile_key = profile.profile_key;
+            GLOBAL_STATE.run_conf.profile = profile;
         }
     }
 
@@ -721,10 +721,11 @@ pub unsafe fn query_and_set_runconf_in_globalstate(check_precopy:bool) -> bool {
     if old_force_tex_cpu_read != GLOBAL_STATE.run_conf.force_tex_cpu_read {
         changed = true;
     }
-    write_log_file(&format!("runconf: precopy data: {}, force tex cpu read: {}, profile: {} (setting changed: {})",
+    write_log_file(&format!("runconf: precopy data: {}, force tex cpu read: {} (setting changed: {})",
         GLOBAL_STATE.run_conf.precopy_data, GLOBAL_STATE.run_conf.force_tex_cpu_read,
-        if GLOBAL_STATE.run_conf.profile_key.is_empty() { "<none>" } else { &GLOBAL_STATE.run_conf.profile_key },
-        changed));
+        changed,
+    ));
+    write_log_file(&format!("runconf: game profile: {:?}", GLOBAL_STATE.run_conf.profile));
     changed
 }
 

--- a/Native/hook_core/src/hook_render.rs
+++ b/Native/hook_core/src/hook_render.rs
@@ -442,7 +442,7 @@ pub unsafe extern "system" fn hook_present(
     // Periodically GC the DX9 UpdateTexture source-tracking state.
     // This releases refs we took on sources in `hook_update_texture` that
     // have been sitting around long enough that we no longer need them.
-    {
+    if GLOBAL_STATE.run_conf.profile.snap_use_sysmemtexturetracking {
         let now = SystemTime::now();
         let due = now.duration_since(GLOBAL_STATE.dx9_update_texture_last_gc)
             .map(|d| d.as_secs() >= 30)

--- a/Native/util/src/game_profile.rs
+++ b/Native/util/src/game_profile.rs
@@ -45,16 +45,32 @@ pub struct GameProfile {
     pub reverse_normals: bool,
     pub update_tangent_space: bool,
     pub data_path_name: String,
+    /// Whether to enable dx9 systemmem tracking for texture snapshots.  Default is false. 
+    /// 
+    /// At least one game (2026g1) creates textures in 
+    /// the sysmem d3d pool, and then creates another for the device to use in the default d3d pool, 
+    /// and copies the data from source to dest with UpdateTexture.
+    /// The textures used for rendering are thus in the default pool and cannot be snapshotted.  
+    /// 
+    /// When this 
+    /// setting is enabled, we track and keep references to the original textures so that we can snap from those instead.
+    /// This also enables a garbage collector for the systemmem copies which introduces some performance hit (~10ms every 30secs on my 2015 desktop).
+    /// The system textures will be kept for at least 5 minutes after creation.  Once disposed the textures involved may be 
+    /// un-snapshotable, but sometimes loading a new level (to trigger the game to produce a fresh systemmem texture) works to refresh them.
+    pub snap_use_sysmemtexturetracking: bool,
 }
+
+pub const EMPTY_GAME_PROFILE:GameProfile = GameProfile {
+    profile_key: String::new(),
+    reverse_normals: false,
+    update_tangent_space: true,
+    data_path_name: String::new(),
+    snap_use_sysmemtexturetracking: false,
+};
 
 impl Default for GameProfile {
     fn default() -> Self {
-        GameProfile {
-            profile_key: String::new(),
-            reverse_normals: false,
-            update_tangent_space: true,
-            data_path_name: String::new(),
-        }
+        EMPTY_GAME_PROFILE
     }
 }
 
@@ -141,12 +157,16 @@ unsafe fn read_profile_from_key(profile_path: &str) -> GameProfile {
         .unwrap_or(true); // default is true, matching F# DefaultGameProfile
     let data_path_name = reg_query_string(profile_path, "GameProfileDataPathName")
         .unwrap_or_default();
+    let snap_use_sysmemtexturetracking = reg_query_dword(profile_path, "GameProfileSnapUseSysmemTextureTracking")
+        .map(|v| v > 0)
+        .unwrap_or(false);
 
     GameProfile {
         profile_key: profile_path.to_owned(),
         reverse_normals,
         update_tangent_space,
         data_path_name,
+        snap_use_sysmemtexturetracking
     }
 }
 


### PR DESCRIPTION
- Add a new setting to control whether the new systex tracking method should be used (default false)
- When that is true, do the initial hook of updatetexture and also enabled the gc in hook_present