### PR TITLE
Add HalfFour support for texture coordinates

### DIFF
--- a/MMManaged/MeshUtil.fs
+++ b/MMManaged/MeshUtil.fs
@@ -489,6 +489,7 @@ map_Kd $$filename
         | SDXDT.Ubyte4 -> 4
         | SDXDT.Color -> 4
         | SDXDT.HalfTwo -> 4
+        | SDXDT.HalfFour -> 8
         | _ -> failwithf "Some lazy person didn't fill in the size of vert decl type %A" dtype
 
     /// Returns the total vertex size (in bytes), using the specified declaration

--- a/MMManaged/ModDBInterop.fs
+++ b/MMManaged/ModDBInterop.fs
@@ -996,6 +996,12 @@ module ModDBInterop =
                                     let srcTC = srcTex.[v.Tex]
                                     bw.Write(MonoGameHelpers.floatToHalfUint16 srcTC.X)
                                     bw.Write(MonoGameHelpers.floatToHalfUint16 srcTC.Y)
+                                | MMET.DeclType(dt) when dt = SDXVT.HalfFour ->
+                                    let srcTC = srcTex.[v.Tex]
+                                    bw.Write(MonoGameHelpers.floatToHalfUint16 srcTC.X)
+                                    bw.Write(MonoGameHelpers.floatToHalfUint16 srcTC.Y)
+                                    bw.Write(uint16 0)
+                                    bw.Write(uint16 0)
                                 | MMET.Format(f) when f = SDXF.R32G32_Float ->
                                     let srcTC = srcTex.[v.Tex]
                                     bw.Write(srcTC.X)

--- a/MMManaged/Snapshot.fs
+++ b/MMManaged/Snapshot.fs
@@ -52,6 +52,12 @@ module Extractors =
     let xPosFromFloat3 (br:SourceReader) = br.ReadSingle(), br.ReadSingle(), br.ReadSingle()
     let xTexFromFloat2 (br:SourceReader) = br.ReadSingle(), br.ReadSingle()
     let xTexFromHalfFloat2 (br:SourceReader) = MonoGameHelpers.halfUint16ToFloat(br.ReadUInt16()), MonoGameHelpers.halfUint16ToFloat(br.ReadUInt16())
+    let xTexFromHalfFloat4 (br:SourceReader) =
+        let x = MonoGameHelpers.halfUint16ToFloat(br.ReadUInt16())
+        let y = MonoGameHelpers.halfUint16ToFloat(br.ReadUInt16())
+        br.ReadUInt16() |> ignore // z - unused for now
+        br.ReadUInt16() |> ignore // w - unused for now
+        (x, y)
     let xTexFrom2S16_x2S16 (br:SourceReader) = 
         let x1 = br.ReadInt16()
         let x2 = br.ReadInt16()
@@ -239,6 +245,8 @@ module Snapshot =
                         fns.TexCoord (Extractors.xTexFromFloat2 reader)
                     | SDXVertexDeclType.HalfTwo ->
                         fns.TexCoord (Extractors.xTexFromHalfFloat2 reader)
+                    | SDXVertexDeclType.HalfFour ->
+                        fns.TexCoord (Extractors.xTexFromHalfFloat4 reader)
                     | _ -> failwithf "Unsupported type for texture coordinate: %A" dt
                 | MMET.Format(f) ->
                     match f with


### PR DESCRIPTION
Fixes snapshot failure when a DX9 game stores texture coordinates as HalfFour (4 half-precision floats). Reads the first two components as the UV and discards the remaining two for now. Also adds the size mapping (8 bytes) and write-back support.

https://claude.ai/code/session_01Ep4ZyoLyyP7KC4B5rc4XG5