### PR TITLE
Add texture checksum as secondary mesh identifier

### DIFF
--- a/MMManaged/CoreTypes.fs
+++ b/MMManaged/CoreTypes.fs
@@ -366,6 +366,12 @@ module CoreTypes =
         UpdateTangentSpace: bool option
         /// Snapshot profile; optional since many older mods will not have this.
         Profile: SnapProfile option
+        /// Optional per-stage texture CRC32 checksum constraints.  Each entry
+        /// is `(stage, crc32)`.  When non-empty, the mod only renders while
+        /// the textures bound on the listed stages have the listed checksums.
+        /// Parsed from `Tex0Checksum`..`Tex3Checksum` in the mod YAML.  The
+        /// common unconstrained case uses an empty list.
+        TextureChecksums: (int * uint32) list
     }
 
     /// Union Parent type for the yaml objects.

--- a/MMManaged/InteropTypes.fs
+++ b/MMManaged/InteropTypes.fs
@@ -153,11 +153,22 @@ module InteropTypes =
         [<MarshalAs(UnmanagedType.ByValTStr, SizeConst=8192)>]
         PixelShaderPath: string
         SnapProfile: ModSnapProfile
-        /// Whether the data has been loaded for this mod.  If this is false only some metadata will be available 
-        /// (extracted from the yaml files).  The full mod data including meshes and the meshrelation 
+        /// Whether the data has been loaded for this mod.  If this is false only some metadata will be available
+        /// (extracted from the yaml files).  The full mod data including meshes and the meshrelation
         /// can be loaded with ModDBInterop.loadModData.
         [<MarshalAs(UnmanagedType.U1)>]
         DataAvailable: bool
+        /// Per-stage texture CRC32 checksum constraints.  Only slots whose
+        /// bit is set in `TexChecksumMask` are meaningful.  When a bit is set
+        /// the mod only renders if the texture bound on that stage has the
+        /// matching checksum recorded by native code.
+        Tex0Checksum: uint32
+        Tex1Checksum: uint32
+        Tex2Checksum: uint32
+        Tex3Checksum: uint32
+        /// Bitmask over Tex[0..3]Checksum; bit i set iff slot i is an
+        /// active constraint.  0 means "no constraint", which is the common case.
+        TexChecksumMask: byte
     }
 
     /// Default value.  Also used as an error return value, since we don't throw exceptions accross interop.
@@ -182,6 +193,11 @@ module InteropTypes =
         UpdateTangentSpace = -1
         SnapProfile = EmptyModSnapProfile
         DataAvailable = false
+        Tex0Checksum = 0u
+        Tex1Checksum = 0u
+        Tex2Checksum = 0u
+        Tex3Checksum = 0u
+        TexChecksumMask = 0uy
     }
 
     [<StructLayout(LayoutKind.Sequential, Pack=4)>]
@@ -373,6 +389,14 @@ module NativeImportsAsD3D11 =
     /// WARNING: the data address in the memory buffer is only valid until the next call to GetPixelShader().
     /// If you call this function twice in succession and then use the results from the first call, it will crash.
     extern [<MarshalAs(UnmanagedType.U1)>]bool GetPixelShader(System.IntPtr buffer)
+    [< DllImport("d3d11.dll", CallingConvention = CallingConvention.StdCall) >]
+    /// Retrieves the CRC32 checksum recorded for a given native texture resource
+    /// pointer.  Returns 0 when the checksum is unknown.
+    extern uint32 GetTextureChecksum(nativeint texPtr)
+    [< DllImport("d3d11.dll", CallingConvention = CallingConvention.StdCall) >]
+    /// Retrieves the CRC32 checksum of the texture currently bound on the
+    /// given stage.  Returns 0 for unknown/unbound/out-of-range stages.
+    extern uint32 GetBoundTextureChecksum(uint32 stage)
 
 module NativeImportsAsD3D9 =
     [< DllImport("d3d9.dll", CallingConvention = CallingConvention.StdCall ) >]
@@ -393,6 +417,14 @@ module NativeImportsAsD3D9 =
     /// WARNING: the data address in the memory buffer is only valid until the next call to GetPixelShader().
     /// If you call this function twice in succession and then use the results from the first call, it will crash.
     extern [<MarshalAs(UnmanagedType.U1)>]bool GetPixelShader(System.IntPtr buffer)
+    [< DllImport("d3d9.dll", CallingConvention = CallingConvention.StdCall) >]
+    /// Retrieves the CRC32 checksum recorded for a given native texture resource
+    /// pointer.  Returns 0 when the checksum is unknown.
+    extern uint32 GetTextureChecksum(nativeint texPtr)
+    [< DllImport("d3d9.dll", CallingConvention = CallingConvention.StdCall) >]
+    /// Retrieves the CRC32 checksum of the texture currently bound on the
+    /// given stage.  Returns 0 for unknown/unbound/out-of-range stages.
+    extern uint32 GetBoundTextureChecksum(uint32 stage)
 
 module NativeImportsAsMMNative =
     [< DllImport("mm_native.dll", CallingConvention = CallingConvention.StdCall ) >]
@@ -407,3 +439,11 @@ module NativeImportsAsMMNative =
     extern [<MarshalAs(UnmanagedType.U1)>]bool SaveTexture(int index, [<MarshalAs(UnmanagedType.LPWStr)>]string filepath)
     [< DllImport("mm_native.dll", CallingConvention = CallingConvention.StdCall ) >]
     extern [<MarshalAs(UnmanagedType.U1)>]bool GetPixelShader(System.IntPtr buffer)
+    [< DllImport("mm_native.dll", CallingConvention = CallingConvention.StdCall ) >]
+    /// Retrieves the CRC32 checksum recorded for a given native texture resource
+    /// pointer.  Returns 0 when the checksum is unknown.
+    extern uint32 GetTextureChecksum(nativeint texPtr)
+    [< DllImport("mm_native.dll", CallingConvention = CallingConvention.StdCall ) >]
+    /// Retrieves the CRC32 checksum of the texture currently bound on the
+    /// given stage.  Returns 0 for unknown/unbound/out-of-range stages.
+    extern uint32 GetBoundTextureChecksum(uint32 stage)

--- a/MMManaged/ModDB.fs
+++ b/MMManaged/ModDB.fs
@@ -318,6 +318,32 @@ module ModDB =
 
         let computeTS = node |> Yaml.getOptionalValue "UpdateTangentSpace" |> Yaml.toOptionalBool
 
+        // Optional per-stage texture CRC32 checksum constraints.  The YAML
+        // stores them as hex strings (with or without a leading "0x"); we
+        // parse to uint32.  Slots not present in the yaml contribute no
+        // entry to the list (empty list == "unconstrained", the common case).
+        let parseHexCs (stage:int) (raw:string option) : (int * uint32) option =
+            match raw with
+            | None -> None
+            | Some s ->
+                let s = s.Trim()
+                if s = "" then None
+                else
+                    let s =
+                        if s.StartsWith("0x", System.StringComparison.OrdinalIgnoreCase)
+                           || s.StartsWith("0X", System.StringComparison.OrdinalIgnoreCase)
+                        then s.Substring 2 else s
+                    match System.UInt32.TryParse(s, System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture) with
+                    | true, v -> Some (stage, v)
+                    | false, _ ->
+                        log().Warn "Mod %s: could not parse Tex%dChecksum '%s' as hex uint32" modName stage s
+                        None
+        let texChecksums =
+            [0..3]
+            |> List.choose (fun stage ->
+                let key = sprintf "Tex%dChecksum" stage
+                node |> Yaml.getOptionalValue key |> Yaml.toOptionalString |> parseHexCs stage)
+
         let md = {
             DBMod.RefName = refName
             Type = modType
@@ -332,6 +358,7 @@ module ModDB =
             ParentModName = parentModName
             UpdateTangentSpace = computeTS
             Profile = profile
+            TextureChecksums = texChecksums
         }
 
         log().Info "Mod: %A: type: %A, ref: %A, weightmode: %A, override textures: %d: profile: %A" modName modType refName weightMode numOverrideTextures profile

--- a/MMManaged/ModDBInterop.fs
+++ b/MMManaged/ModDBInterop.fs
@@ -260,10 +260,20 @@ module ModDBInterop =
             | None -> -1
             | Some(upd) -> if upd then 1 else 0
 
-        let profile = 
-            match meshrel.DBMod.Profile with 
+        let profile =
+            match meshrel.DBMod.Profile with
             | None -> EmptyModSnapProfile
             | Some(p) -> SnapshotProfile.toInteropStruct p
+
+        // Collapse the optional per-stage checksum constraints into the
+        // flat (checksums + mask) representation that crosses the interop
+        // boundary.  Slots not listed in `TextureChecksums` contribute 0.
+        let texCs = Array.create 4 0u
+        let mutable texMask = 0uy
+        for (stage, crc) in meshrel.DBMod.TextureChecksums do
+            if stage >= 0 && stage < 4 then
+                texCs.[stage] <- crc
+                texMask <- texMask ||| (1uy <<< stage)
 
         {
             InteropTypes.ModData.ModType = modType
@@ -286,6 +296,11 @@ module ModDBInterop =
             UpdateTangentSpace = updateTS
             SnapProfile = profile
             DataAvailable = meshrel.IsBuilt
+            Tex0Checksum = texCs.[0]
+            Tex1Checksum = texCs.[1]
+            Tex2Checksum = texCs.[2]
+            Tex3Checksum = texCs.[3]
+            TexChecksumMask = texMask
         }
 
     let emptyMod = InteropTypes.EmptyModData

--- a/MMManaged/Snapshot.fs
+++ b/MMManaged/Snapshot.fs
@@ -941,7 +941,8 @@ module Snapshot =
             match getBoundChecksum with
             | None -> ()
             | Some(fn) ->
-                for stage in texturePaths.Keys do
+                let keys = texturePaths |> Map.toSeq |> Seq.map fst |> Array.ofSeq
+                for stage in keys do
                     if stage >= 0 && stage < 4 then
                         let cs = fn (uint32 stage)
                         if cs <> 0u then

--- a/MMManaged/Snapshot.fs
+++ b/MMManaged/Snapshot.fs
@@ -140,11 +140,20 @@ module Snapshot =
         BlendWeight: float32 * float32 * float32 * float32 -> unit
     }
 
-    type SnapMeta() = 
+    type SnapMeta() =
         let mutable profile:CoreTypes.SnapProfile = SnapshotProfile.EmptyProfile
         let mutable context:string = ""
+        // Identifier for the algorithm used to compute `TextureChecksums`.
+        // Stable string so that future algorithm changes won't silently
+        // invalidate mods that were authored against the previous scheme.
+        let mutable textureChecksumAlgo:string = "crc32-center64"
+        // Per-stage texture CRC32 checksum captured at snapshot time, keyed
+        // by stage index.  Stored as hex strings (8 chars, no prefix) so the
+        // YAML is human-readable.  Stages we couldn't read are omitted.
+        let mutable textureChecksums:System.Collections.Generic.Dictionary<int,string> =
+            System.Collections.Generic.Dictionary<int,string>()
 
-        static member Create(profile):SnapMeta = 
+        static member Create(profile):SnapMeta =
             let p = SnapMeta()
             p.Profile <- profile
             p.Context <- CoreState.Context
@@ -152,6 +161,8 @@ module Snapshot =
 
         member x.Profile with get() = profile and set v = profile <- v
         member x.Context with get() = context and set v = context <- v
+        member x.TextureChecksumAlgo with get() = textureChecksumAlgo and set v = textureChecksumAlgo <- v
+        member x.TextureChecksums with get() = textureChecksums and set v = textureChecksums <- v
 
     /// Reads a vertex element.  Uses the read output functions to pipe the data to an appropriate handler
     /// function, depending on the type.
@@ -915,7 +926,29 @@ module Snapshot =
             let metaFile = Path.Combine(baseDir, (sprintf "%s_Meta.yaml" sbasename))
             let serializer = Serializer()
             let sw = new StringWriter();
-            serializer.Serialize(sw, SnapMeta.Create(snapProfile))
+            let meta = SnapMeta.Create(snapProfile)
+            // Record texture checksums for the stages that actually had a
+            // texture saved.  The native helper returns 0 for unknown stages
+            // (e.g. textures we couldn't read); we omit those.  The algorithm
+            // identifier is set here so any future change to the native
+            // hashing scheme can be detected by mod tooling.
+            let getBoundChecksum =
+                match CoreState.Context with
+                | "mm_native" -> Some(NativeImportsAsMMNative.GetBoundTextureChecksum)
+                | "d3d9" -> Some(NativeImportsAsD3D9.GetBoundTextureChecksum)
+                | "d3d11" -> Some(NativeImportsAsD3D11.GetBoundTextureChecksum)
+                | _ -> None
+            match getBoundChecksum with
+            | None -> ()
+            | Some(fn) ->
+                for stage in texturePaths.Keys do
+                    if stage >= 0 && stage < 4 then
+                        let cs = fn (uint32 stage)
+                        if cs <> 0u then
+                            meta.TextureChecksums.[stage] <- sprintf "%08x" cs
+                        else
+                            log.Info "No texture checksum recorded for snapshot stage %d" stage
+            serializer.Serialize(sw, meta)
             File.WriteAllText(metaFile, (sw.ToString()))
 
             log.Info "Wrote snapshot %d to %s" snapshotNum.Value baseDir

--- a/Native/Cargo.lock
+++ b/Native/Cargo.lock
@@ -40,6 +40,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +66,15 @@ dependencies = [
  "serde_yaml",
  "shared_dx",
  "winapi",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -458,6 +473,7 @@ version = "0.1.0"
 dependencies = [
  "aho-corasick",
  "chrono",
+ "crc32fast",
  "shared_dx",
  "winapi",
 ]

--- a/Native/global_state/src/global_state.rs
+++ b/Native/global_state/src/global_state.rs
@@ -28,6 +28,14 @@ use util::game_profile::GameProfile;
 
 pub const MAX_STAGE: usize = 40;
 
+/// Number of texture stages that participate in the texture-checksum
+/// disambiguation path.  A mod YAML can declare `Tex0Checksum` through
+/// `Tex(MAX_CHECKSUM_STAGES-1)Checksum` to require that the texture bound
+/// on that stage at draw time hashes to the given value.  The bound
+/// textures on these stages are tracked unconditionally (i.e. outside of
+/// selection mode) in `HookState::bound_textures_per_stage`.
+pub const MAX_CHECKSUM_STAGES: usize = 4;
+
 /// Enable this to dump out a file containing metrics for primitives every
 /// few seconds.  The file is `rendered_last_frame.txt` and is stored in the
 /// same directory as logs.  It contains one line for each primitive count,
@@ -120,6 +128,34 @@ pub struct HookState {
     pub dx9_update_texture_deque: Option<VecDeque<(usize, SystemTime)>>,
     /// DX9 only: the last time the GC pass was run (from `hook_present`).
     pub dx9_update_texture_last_gc: SystemTime,
+    /// Map of texture *resource* pointer (as `usize`) to its CRC32 checksum,
+    /// computed when the texture was created or updated. Key convention:
+    /// * DX9: the `IDirect3DBaseTexture9*` returned by `CreateTexture`
+    ///   (or, for games using SYSTEMMEM staging, the destination pointer
+    ///   recorded in `dx9_update_texture_map`).
+    /// * DX11: the `ID3D11Texture2D*` returned by `CreateTexture2D`.
+    ///
+    /// Looked up via `srv_to_resource` (DX11) or directly (DX9) at draw
+    /// time when a mod constrains the bound texture's checksum, and also
+    /// at snapshot time so the checksum can be written to the snapshot
+    /// meta file for the modder to see.  Absence means "unknown" (either
+    /// the texture wasn't lockable/readable, or it was created before the
+    /// hook was installed).
+    pub texture_checksums: Option<FnvHashMap<usize, u32>>,
+    /// DX11 only: map of `ID3D11ShaderResourceView*` pointer (as `usize`) to
+    /// the underlying resource pointer (as `usize`) used to key
+    /// `texture_checksums`.  Populated lazily the first time a given SRV
+    /// is observed in `hook_PSSetShaderResources`; entries are kept
+    /// indefinitely (pointer collisions on freed SRVs are possible but
+    /// harmless - the worst case is a stale lookup that simply misses).
+    pub srv_to_resource: Option<FnvHashMap<usize, usize>>,
+    /// The texture resource pointer (as `usize`) currently bound on each
+    /// of the first `MAX_CHECKSUM_STAGES` texture stages.  Written
+    /// unconditionally by `hook_set_texture` (DX9) and
+    /// `hook_PSSetShaderResources` (DX11); consumed by `mod_render::select`
+    /// when a candidate mod has a texture checksum constraint.  Zero means
+    /// "no texture currently bound".
+    pub bound_textures_per_stage: [usize; MAX_CHECKSUM_STAGES],
     pub making_selection: bool,
     pub in_dip: bool,
     pub in_hook_release: bool,
@@ -185,6 +221,9 @@ pub static mut GLOBAL_STATE: HookState = HookState {
     dx9_update_texture_tracked_srcs: None,
     dx9_update_texture_deque: None,
     dx9_update_texture_last_gc: std::time::UNIX_EPOCH,
+    texture_checksums: None,
+    srv_to_resource: None,
+    bound_textures_per_stage: [0usize; MAX_CHECKSUM_STAGES],
     making_selection: false,
     in_dip: false,
     in_hook_release: false,

--- a/Native/hook_core/src/hook_device.rs
+++ b/Native/hook_core/src/hook_device.rs
@@ -6,6 +6,7 @@ pub use winapi::shared::windef::HWND;
 pub use winapi::shared::winerror::{E_FAIL, S_OK};
 pub use winapi::um::winnt::{HRESULT, LPCWSTR};
 use std;
+use std::mem::MaybeUninit;
 use std::ptr::null_mut;
 use std::time::Instant;
 use shared_dx::types::*;
@@ -15,6 +16,7 @@ use shared_dx::error::*;
 use input;
 use util;
 use util::*;
+use util::tex_checksum;
 use global_state::{GLOBAL_STATE, GLOBAL_STATE_LOCK};
 
 use device_state::{DEVICE_STATE, dev_state};
@@ -82,6 +84,10 @@ unsafe fn hook_d3d9_device(
     //(*vtbl).BeginScene = hook_begin_scene;
     (*vtbl).Present = hook_present;
     (*vtbl).parent.Release = hook_release;
+    // Always hook SetTexture so that we can track the texture bound on each
+    // stage (used for the texture-checksum mesh-disambiguation path in
+    // mod_render::select and historically for selection mode).
+    (*vtbl).SetTexture = crate::hook_render::hook_set_texture;
     // Always hook CreateTexture; the hook checks force_tex_cpu_read at runtime
     // to decide whether to change DEFAULT pool to MANAGED for snapshotting.
     // JMQNOTE: This d3d9-specific change sets up a hook method that converts to using the MANAGED pool 
@@ -139,6 +145,122 @@ unsafe fn hook_d3d9_device(
         real_set_pixel_sc_i,
         real_set_pixel_sc_b,
     ))
+}
+
+/// Default sample-window size (in pixels) for the texture-checksum path.
+/// The algorithm name written to snapshot meta must match this value.
+const TEX_CHECKSUM_SAMPLE_SIZE: u32 = 64;
+
+/// Classification of a D3DFORMAT for the checksum helper.
+enum FmtKind {
+    /// Plain `bpp` bytes per pixel.
+    Uncompressed { bpp_bytes: u32 },
+    /// Block-compressed with `block_bytes` bytes per 4x4 block.
+    Block { block_bytes: u32 },
+}
+
+/// Return the pixel-layout classification we need to walk a locked surface
+/// when computing a texture checksum.  `None` means "we don't know how to
+/// hash this format" and the caller should skip the texture.
+fn classify_d3d_format(format: D3DFORMAT) -> Option<FmtKind> {
+    // These FourCC codes match the values produced by MAKEFOURCC('D','X','T','1')
+    // etc., which is how D3D9 encodes the BC1-BC3 formats in a D3DFORMAT.
+    const FOURCC_DXT1: u32 = 0x31545844;
+    const FOURCC_DXT2: u32 = 0x32545844;
+    const FOURCC_DXT3: u32 = 0x33545844;
+    const FOURCC_DXT4: u32 = 0x34545844;
+    const FOURCC_DXT5: u32 = 0x35545844;
+    match format {
+        // 32-bit formats
+        D3DFMT_A8R8G8B8 | D3DFMT_X8R8G8B8 | D3DFMT_A8B8G8R8 | D3DFMT_X8B8G8R8 |
+        D3DFMT_A2R10G10B10 | D3DFMT_A2B10G10R10 | D3DFMT_G16R16 |
+        D3DFMT_Q8W8V8U8 | D3DFMT_V16U16 | D3DFMT_X8L8V8U8 | D3DFMT_A2W10V10U10 |
+        D3DFMT_D32 | D3DFMT_D24S8 | D3DFMT_D24X8 | D3DFMT_D24X4S4 | D3DFMT_D32F_LOCKABLE |
+        D3DFMT_INDEX32
+            => Some(FmtKind::Uncompressed { bpp_bytes: 4 }),
+        // 16-bit formats
+        D3DFMT_R5G6B5 | D3DFMT_X1R5G5B5 | D3DFMT_A1R5G5B5 | D3DFMT_A4R4G4B4 |
+        D3DFMT_R3G3B2 | D3DFMT_A8R3G3B2 | D3DFMT_X4R4G4B4 |
+        D3DFMT_A8L8 | D3DFMT_V8U8 | D3DFMT_L6V5U5 | D3DFMT_D16 | D3DFMT_D15S1 |
+        D3DFMT_D16_LOCKABLE | D3DFMT_INDEX16
+            => Some(FmtKind::Uncompressed { bpp_bytes: 2 }),
+        // 8-bit formats
+        D3DFMT_R8G8B8
+            => Some(FmtKind::Uncompressed { bpp_bytes: 3 }),
+        D3DFMT_A8 | D3DFMT_L8 | D3DFMT_A4L4 | D3DFMT_P8
+            => Some(FmtKind::Uncompressed { bpp_bytes: 1 }),
+        f => {
+            let fv = f as u32;
+            match fv {
+                FOURCC_DXT1 => Some(FmtKind::Block { block_bytes: 8 }),
+                FOURCC_DXT2 | FOURCC_DXT3 | FOURCC_DXT4 | FOURCC_DXT5
+                    => Some(FmtKind::Block { block_bytes: 16 }),
+                _ => None,
+            }
+        }
+    }
+}
+
+/// Attempt to compute a checksum for mip 0 of a DX9 texture.
+/// The texture is locked `D3DLOCK_READONLY`; this will fail for textures in
+/// non-lockable pools (e.g. `D3DPOOL_DEFAULT` without `force_tex_cpu_read`).
+/// In that case we return `None` and the caller skips caching.
+unsafe fn try_checksum_dx9_texture(tex: *mut IDirect3DTexture9) -> Option<u32> {
+    if tex.is_null() {
+        return None;
+    }
+    let mut desc = MaybeUninit::<D3DSURFACE_DESC>::uninit();
+    let hr = (*tex).GetLevelDesc(0, desc.as_mut_ptr());
+    if hr != 0 {
+        return None;
+    }
+    let desc = desc.assume_init();
+    let kind = classify_d3d_format(desc.Format)?;
+
+    let mut locked = MaybeUninit::<D3DLOCKED_RECT>::uninit();
+    const D3DLOCK_READONLY: DWORD = 0x00000010;
+    let hr = (*tex).LockRect(0, locked.as_mut_ptr(), null_mut(), D3DLOCK_READONLY);
+    if hr != 0 {
+        return None;
+    }
+    let locked = locked.assume_init();
+
+    // The slice length is the number of full rows in the locked surface: for
+    // uncompressed formats that's Height rows, for block-compressed it's
+    // ceil(Height/4) block-rows.
+    let (rows, pitch_usable) = match kind {
+        FmtKind::Uncompressed { .. } => (desc.Height as usize, locked.Pitch as usize),
+        FmtKind::Block { .. } => (((desc.Height + 3) / 4) as usize, locked.Pitch as usize),
+    };
+    let buf_len = rows.saturating_mul(pitch_usable);
+    let data = std::slice::from_raw_parts(locked.pBits as *const u8, buf_len);
+
+    let result = match kind {
+        FmtKind::Uncompressed { bpp_bytes } => tex_checksum::compute_uncompressed(
+            data, desc.Width, desc.Height, locked.Pitch as u32, bpp_bytes, TEX_CHECKSUM_SAMPLE_SIZE),
+        FmtKind::Block { block_bytes } => tex_checksum::compute_block_compressed(
+            data, desc.Width, desc.Height, locked.Pitch as u32, block_bytes, TEX_CHECKSUM_SAMPLE_SIZE),
+    };
+
+    let _ = (*tex).UnlockRect(0);
+    result
+}
+
+/// Insert a checksum into the global map, creating it if needed.
+unsafe fn insert_checksum(key: usize, cs: u32) {
+    if GLOBAL_STATE.texture_checksums.is_none() {
+        GLOBAL_STATE.texture_checksums = Some(fnv::FnvHashMap::default());
+    }
+    if let Some(m) = GLOBAL_STATE.texture_checksums.as_mut() {
+        m.insert(key, cs);
+    }
+}
+
+/// Remove a checksum entry if present.
+unsafe fn remove_checksum(key: usize) {
+    if let Some(m) = GLOBAL_STATE.texture_checksums.as_mut() {
+        m.remove(&key);
+    }
 }
 
 /// Hook for IDirect3DDevice9::CreateTexture.
@@ -259,7 +381,26 @@ unsafe extern "system" fn hook_update_texture(
         }
     }
 
-    (real_fn)(THIS, pSourceTexture, pDestinationTexture)
+    let hr = (real_fn)(THIS, pSourceTexture, pDestinationTexture);
+
+    // After a successful update, checksum the source (which is lockable,
+    // being SYSTEMMEM/MANAGED for games that use this staging path) and
+    // store it under the destination pointer key - this is the key that
+    // `SetTexture` will later bind for draw calls. Mirror the hash under
+    // the source key too so subsequent update cycles that skip the
+    // AddRef can still benefit from the cached value.
+    if hr == 0 && !pSourceTexture.is_null() && !pDestinationTexture.is_null() {
+        // Both D3D9 base-texture types we see here are IDirect3DTexture9 in
+        // practice; for non-2D textures the cast is still safe because we
+        // classify by format and bail out early if unsupported.
+        let src_tex = pSourceTexture as *mut IDirect3DTexture9;
+        if let Some(cs) = try_checksum_dx9_texture(src_tex) {
+            insert_checksum(pDestinationTexture as usize, cs);
+            insert_checksum(pSourceTexture as usize, cs);
+        }
+    }
+
+    hr
 }
 
 /// Garbage-collect the DX9 UpdateTexture source-tracking state.
@@ -338,11 +479,19 @@ pub unsafe fn dx9_update_texture_gc() {
             if let Some(set) = GLOBAL_STATE.dx9_update_texture_tracked_srcs.as_mut() {
                 set.remove(&src_key);
             }
+            // Drop any cached checksum keyed by the now-dead source pointer.
+            remove_checksum(src_key);
             released_srcs.push(src_key);
         }
     }
 
     if !released_srcs.is_empty() {
+        // Drop the dest->src entries that referenced any of the released
+        // source pointers. The corresponding dest-keyed checksum entries
+        // can outlive this pass: the destination texture may still be alive
+        // and carrying the same contents, so we deliberately leave
+        // `texture_checksums[dest]` in place. If the dest gets overwritten
+        // by a future UpdateTexture the new checksum will replace it.
         if let Some(map) = GLOBAL_STATE.dx9_update_texture_map.as_mut() {
             map.retain(|_, v| !released_srcs.contains(v));
         }

--- a/Native/hook_core/src/hook_device_d3d11.rs
+++ b/Native/hook_core/src/hook_device_d3d11.rs
@@ -75,6 +75,7 @@ use shared_dx::{util::write_log_file,
 use util::mm_verify_load;
 use device_state::{DEVICE_STATE, dev_state_d3d11_nolock, dev_state_d3d11_write};
 use crate::hook_render_d3d11::*;
+use util::tex_checksum;
 
 static mut DEVICE_REALFN: RwLock<Option<HookDirect3D11Device>> = RwLock::new(None);
 
@@ -1044,6 +1045,107 @@ unsafe extern "system" fn hook_CreateBuffer(
     res
 }
 
+/// Default sample-window size used when computing DX11 texture checksums.
+/// This must match `TEX_CHECKSUM_SAMPLE_SIZE` in `hook_device.rs` (the DX9
+/// side) and the algorithm name written into the snapshot meta file.
+const TEX_CHECKSUM_SAMPLE_SIZE: u32 = 64;
+
+/// Classify a DXGI_FORMAT for the checksum helper.  See the DX9 equivalent
+/// in `hook_device.rs::classify_d3d_format`.
+enum DxgiFmtKind {
+    Uncompressed { bpp_bytes: u32 },
+    Block { block_bytes: u32 },
+}
+
+fn classify_dxgi_format(format: DXGI_FORMAT) -> Option<DxgiFmtKind> {
+    use winapi::shared::dxgiformat::*;
+    let bpp = |n:u32| Some(DxgiFmtKind::Uncompressed { bpp_bytes: n });
+    let blk = |n:u32| Some(DxgiFmtKind::Block { block_bytes: n });
+    match format {
+        // 128-bit
+        DXGI_FORMAT_R32G32B32A32_TYPELESS | DXGI_FORMAT_R32G32B32A32_FLOAT |
+        DXGI_FORMAT_R32G32B32A32_UINT | DXGI_FORMAT_R32G32B32A32_SINT => bpp(16),
+        // 96-bit
+        DXGI_FORMAT_R32G32B32_TYPELESS | DXGI_FORMAT_R32G32B32_FLOAT |
+        DXGI_FORMAT_R32G32B32_UINT | DXGI_FORMAT_R32G32B32_SINT => bpp(12),
+        // 64-bit
+        DXGI_FORMAT_R16G16B16A16_TYPELESS | DXGI_FORMAT_R16G16B16A16_FLOAT |
+        DXGI_FORMAT_R16G16B16A16_UNORM | DXGI_FORMAT_R16G16B16A16_UINT |
+        DXGI_FORMAT_R16G16B16A16_SNORM | DXGI_FORMAT_R16G16B16A16_SINT |
+        DXGI_FORMAT_R32G32_TYPELESS | DXGI_FORMAT_R32G32_FLOAT |
+        DXGI_FORMAT_R32G32_UINT | DXGI_FORMAT_R32G32_SINT |
+        DXGI_FORMAT_R32G8X24_TYPELESS | DXGI_FORMAT_D32_FLOAT_S8X24_UINT |
+        DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS | DXGI_FORMAT_X32_TYPELESS_G8X24_UINT => bpp(8),
+        // 32-bit
+        DXGI_FORMAT_R10G10B10A2_TYPELESS | DXGI_FORMAT_R10G10B10A2_UNORM | DXGI_FORMAT_R10G10B10A2_UINT |
+        DXGI_FORMAT_R11G11B10_FLOAT |
+        DXGI_FORMAT_R8G8B8A8_TYPELESS | DXGI_FORMAT_R8G8B8A8_UNORM | DXGI_FORMAT_R8G8B8A8_UNORM_SRGB |
+        DXGI_FORMAT_R8G8B8A8_UINT | DXGI_FORMAT_R8G8B8A8_SNORM | DXGI_FORMAT_R8G8B8A8_SINT |
+        DXGI_FORMAT_R16G16_TYPELESS | DXGI_FORMAT_R16G16_FLOAT | DXGI_FORMAT_R16G16_UNORM |
+        DXGI_FORMAT_R16G16_UINT | DXGI_FORMAT_R16G16_SNORM | DXGI_FORMAT_R16G16_SINT |
+        DXGI_FORMAT_R32_TYPELESS | DXGI_FORMAT_D32_FLOAT | DXGI_FORMAT_R32_FLOAT |
+        DXGI_FORMAT_R32_UINT | DXGI_FORMAT_R32_SINT |
+        DXGI_FORMAT_R24G8_TYPELESS | DXGI_FORMAT_D24_UNORM_S8_UINT |
+        DXGI_FORMAT_R24_UNORM_X8_TYPELESS | DXGI_FORMAT_X24_TYPELESS_G8_UINT |
+        DXGI_FORMAT_R9G9B9E5_SHAREDEXP |
+        DXGI_FORMAT_R8G8_B8G8_UNORM | DXGI_FORMAT_G8R8_G8B8_UNORM |
+        DXGI_FORMAT_B8G8R8A8_UNORM | DXGI_FORMAT_B8G8R8X8_UNORM |
+        DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM |
+        DXGI_FORMAT_B8G8R8A8_TYPELESS | DXGI_FORMAT_B8G8R8A8_UNORM_SRGB |
+        DXGI_FORMAT_B8G8R8X8_TYPELESS | DXGI_FORMAT_B8G8R8X8_UNORM_SRGB => bpp(4),
+        // 16-bit
+        DXGI_FORMAT_R8G8_TYPELESS | DXGI_FORMAT_R8G8_UNORM | DXGI_FORMAT_R8G8_UINT |
+        DXGI_FORMAT_R8G8_SNORM | DXGI_FORMAT_R8G8_SINT |
+        DXGI_FORMAT_R16_TYPELESS | DXGI_FORMAT_R16_FLOAT | DXGI_FORMAT_D16_UNORM |
+        DXGI_FORMAT_R16_UNORM | DXGI_FORMAT_R16_UINT | DXGI_FORMAT_R16_SNORM | DXGI_FORMAT_R16_SINT |
+        DXGI_FORMAT_B5G6R5_UNORM | DXGI_FORMAT_B5G5R5A1_UNORM | DXGI_FORMAT_B4G4R4A4_UNORM => bpp(2),
+        // 8-bit
+        DXGI_FORMAT_R8_TYPELESS | DXGI_FORMAT_R8_UNORM | DXGI_FORMAT_R8_UINT |
+        DXGI_FORMAT_R8_SNORM | DXGI_FORMAT_R8_SINT | DXGI_FORMAT_A8_UNORM => bpp(1),
+        // Block-compressed
+        DXGI_FORMAT_BC1_TYPELESS | DXGI_FORMAT_BC1_UNORM | DXGI_FORMAT_BC1_UNORM_SRGB |
+        DXGI_FORMAT_BC4_TYPELESS | DXGI_FORMAT_BC4_UNORM | DXGI_FORMAT_BC4_SNORM => blk(8),
+        DXGI_FORMAT_BC2_TYPELESS | DXGI_FORMAT_BC2_UNORM | DXGI_FORMAT_BC2_UNORM_SRGB |
+        DXGI_FORMAT_BC3_TYPELESS | DXGI_FORMAT_BC3_UNORM | DXGI_FORMAT_BC3_UNORM_SRGB |
+        DXGI_FORMAT_BC5_TYPELESS | DXGI_FORMAT_BC5_UNORM | DXGI_FORMAT_BC5_SNORM |
+        DXGI_FORMAT_BC6H_TYPELESS | DXGI_FORMAT_BC6H_UF16 | DXGI_FORMAT_BC6H_SF16 |
+        DXGI_FORMAT_BC7_TYPELESS | DXGI_FORMAT_BC7_UNORM | DXGI_FORMAT_BC7_UNORM_SRGB => blk(16),
+        _ => None,
+    }
+}
+
+/// Compute a checksum for a DX11 texture's mip 0 initial-data, if present.
+/// We hash the initial data that was passed to CreateTexture2D directly -
+/// this avoids creating a staging texture and Mapping it, which would be
+/// expensive and isn't always possible.  Games that stream texture data via
+/// UpdateSubresource after creation won't have a checksum until a future
+/// iteration adds that hook.
+unsafe fn try_checksum_dx11_initial(
+    desc: &D3D11_TEXTURE2D_DESC,
+    initial: *const D3D11_SUBRESOURCE_DATA,
+) -> Option<u32> {
+    if initial.is_null() {
+        return None;
+    }
+    let kind = classify_dxgi_format(desc.Format)?;
+    let sd = &*initial;
+    if sd.pSysMem.is_null() || sd.SysMemPitch == 0 {
+        return None;
+    }
+    let (rows, pitch) = match kind {
+        DxgiFmtKind::Uncompressed { .. } => (desc.Height as usize, sd.SysMemPitch as usize),
+        DxgiFmtKind::Block { .. } => (((desc.Height + 3) / 4) as usize, sd.SysMemPitch as usize),
+    };
+    let buf_len = rows.saturating_mul(pitch);
+    let data = std::slice::from_raw_parts(sd.pSysMem as *const u8, buf_len);
+    match kind {
+        DxgiFmtKind::Uncompressed { bpp_bytes } => tex_checksum::compute_uncompressed(
+            data, desc.Width, desc.Height, sd.SysMemPitch, bpp_bytes, TEX_CHECKSUM_SAMPLE_SIZE),
+        DxgiFmtKind::Block { block_bytes } => tex_checksum::compute_block_compressed(
+            data, desc.Width, desc.Height, sd.SysMemPitch, block_bytes, TEX_CHECKSUM_SAMPLE_SIZE),
+    }
+}
+
 unsafe extern "system" fn hook_CreateTexture2D(
     THIS: *mut ID3D11Device,
     pDesc: *const D3D11_TEXTURE2D_DESC,
@@ -1127,6 +1229,24 @@ unsafe extern "system" fn hook_CreateTexture2D(
             write_log_file(&format!("hook_CreateTexture2D: retry with unmodified desc succeeded"));
         } else {
             write_log_file(&format!("hook_CreateTexture2D: retry failed"));
+        }
+    }
+
+    // If creation succeeded and the game supplied initial mip-0 data, hash
+    // the data we've been given and cache it under the resulting texture
+    // pointer.  `mod_render::select` will later consult this via the
+    // PSSetShaderResources srv->resource map when a mod constrains the
+    // texture on a particular stage.
+    if res == 0 && !pDesc.is_null() && !pInitialData.is_null()
+        && !ppTexture2D.is_null() && !(*ppTexture2D).is_null()
+    {
+        if let Some(cs) = try_checksum_dx11_initial(&*pDesc, pInitialData) {
+            if GLOBAL_STATE.texture_checksums.is_none() {
+                GLOBAL_STATE.texture_checksums = Some(fnv::FnvHashMap::default());
+            }
+            if let Some(m) = GLOBAL_STATE.texture_checksums.as_mut() {
+                m.insert(*ppTexture2D as usize, cs);
+            }
         }
     }
 

--- a/Native/hook_core/src/hook_render.rs
+++ b/Native/hook_core/src/hook_render.rs
@@ -1,6 +1,7 @@
 use device_state::dev_state_d3d11_nolock;
 use global_state::HookState;
 use global_state::MAX_STAGE;
+use global_state::MAX_CHECKSUM_STAGES;
 use types::d3ddata::ModD3DData9;
 use types::interop::D3D9SnapshotRendData;
 use types::interop::SnapshotRendData;
@@ -339,7 +340,22 @@ pub fn do_per_frame_operations(device: *mut IDirect3DDevice9) -> Result<()> {
     Ok(())
 }
 
+/// Always-on: record the resource pointer bound on stage `tex_stage` into
+/// `bound_textures_per_stage` when the stage is within the checksum range.
+/// This is used by `mod_render::select` to look up a checksum for the
+/// currently bound texture when a mod has a texture constraint.
+#[inline]
+pub fn track_bound_texture(tex_as_int:usize, tex_stage:u32, global_state:&mut HookState) {
+    if tex_stage < MAX_CHECKSUM_STAGES as u32 {
+        global_state.bound_textures_per_stage[tex_stage as usize] = tex_as_int;
+    }
+}
+
 pub fn track_set_texture(tex_as_int:usize, tex_stage:u32, global_state:&mut HookState) {
+    // Note: this function is selection-mode only.  Call `track_bound_texture`
+    // from your hook if you need the always-on per-stage bound-texture slot
+    // (the ptr stored there must be the *resource* pointer, which on DX11
+    // differs from the SRV passed here).
     if !global_state.making_selection {
         return;
     }
@@ -375,6 +391,10 @@ pub (crate) unsafe extern "system" fn hook_set_texture(
     Stage: DWORD,
     pTexture: *mut IDirect3DBaseTexture9,
 ) -> HRESULT {
+    // Always track the bound texture for the checksum stages (DX9 binds the
+    // resource pointer directly, so we can record it here without any
+    // SRV-style resolution).  Selection-mode accounting is layered on top.
+    track_bound_texture(pTexture as usize, Stage, &mut GLOBAL_STATE);
     if GLOBAL_STATE.making_selection {
         track_set_texture(pTexture as usize, Stage, &mut GLOBAL_STATE);
     }
@@ -754,9 +774,14 @@ where
         .and_then(|mods| {
             profile_start!(hdip, mod_select);
 
+            let bound = mod_render::BoundTextures {
+                per_stage: GLOBAL_STATE.bound_textures_per_stage,
+                checksums: GLOBAL_STATE.texture_checksums.as_ref(),
+            };
             let r = mod_render::select(mods,
                 primCount, NumVertices,
-                GLOBAL_STATE.metrics.total_frames);
+                GLOBAL_STATE.metrics.total_frames,
+                &bound);
             profile_end!(hdip, mod_select);
             r
         })

--- a/Native/hook_core/src/hook_render_d3d11.rs
+++ b/Native/hook_core/src/hook_render_d3d11.rs
@@ -32,7 +32,8 @@ use winapi::shared::minwindef::UINT;
 use device_state::{dev_state, dev_state_d3d11_nolock, dev_state_d3d11_write};
 use shared_dx::error::{Result, HookError};
 use crate::hook_device_d3d11::apply_context_hooks;
-use crate::hook_render::{process_metrics, frame_init_clr, frame_load_mods, check_and_render_mod, CheckRenderModResult, track_set_texture, get_override_tex_if_selected};
+use crate::hook_render::{process_metrics, frame_init_clr, frame_load_mods, check_and_render_mod, CheckRenderModResult, track_set_texture, track_bound_texture, get_override_tex_if_selected};
+use global_state::MAX_CHECKSUM_STAGES;
 use crate::{input_commands, debugmode, mod_render};
 use winapi::um::d3d11::D3D11_BUFFER_DESC;
 use crate::debugmode::DebugModeCalledFns;
@@ -412,21 +413,73 @@ pub unsafe extern "system" fn hook_PSSetShaderResources(
         Err(_) => return,
     };
 
-    if GLOBAL_STATE.making_selection {
-        // need to iterate the srvs and track any that are 2d textures
+    // We always want to keep `bound_textures_per_stage` current for the
+    // checksum-disambiguation path (stages < MAX_CHECKSUM_STAGES). The full
+    // active_texture_list accounting only runs in selection mode.
+    let end_slot = StartSlot.saturating_add(NumViews);
+    let touches_checksum_stages = StartSlot < MAX_CHECKSUM_STAGES as u32;
+    let in_selection = GLOBAL_STATE.making_selection;
+    if in_selection || touches_checksum_stages {
         for i in 0..NumViews {
+            let stage = StartSlot + i;
             let srv = *ppShaderResourceViews.offset(i as isize);
-            if !srv.is_null() {
-                let mut desc = MaybeUninit::uninit();
-                (*srv).GetDesc(desc.as_mut_ptr());
-                let desc = desc.assume_init();
-                if desc.ViewDimension == D3D11_SRV_DIMENSION_TEXTURE2D {
-                    let stage = StartSlot + i;
-                    track_set_texture(srv as usize, stage, &mut GLOBAL_STATE);
+            if srv.is_null() {
+                // Clear the bound slot so a stale pointer isn't used after an
+                // unbind.
+                if (stage as usize) < MAX_CHECKSUM_STAGES {
+                    GLOBAL_STATE.bound_textures_per_stage[stage as usize] = 0;
                 }
+                continue;
+            }
+            // Only TEXTURE2D SRVs participate; the existing selection code
+            // already filtered on this, and our checksum store is keyed by
+            // resource pointer which we can only get from a 2D SRV resolve.
+            let mut desc = MaybeUninit::uninit();
+            (*srv).GetDesc(desc.as_mut_ptr());
+            let desc = desc.assume_init();
+            if desc.ViewDimension != D3D11_SRV_DIMENSION_TEXTURE2D {
+                if (stage as usize) < MAX_CHECKSUM_STAGES {
+                    GLOBAL_STATE.bound_textures_per_stage[stage as usize] = 0;
+                }
+                continue;
+            }
+
+            if (stage as usize) < MAX_CHECKSUM_STAGES {
+                // Lazily cache SRV -> resource. GetResource AddRefs the
+                // resource; we only want the pointer as an integer key, so
+                // release immediately.
+                let resource_ptr = {
+                    let cached = GLOBAL_STATE.srv_to_resource
+                        .as_ref()
+                        .and_then(|m| m.get(&(srv as usize)).copied());
+                    match cached {
+                        Some(p) => p,
+                        None => {
+                            let mut resource: *mut ID3D11Resource = null_mut();
+                            (*srv).GetResource(&mut resource);
+                            let rp = resource as usize;
+                            if !resource.is_null() {
+                                (*resource).Release();
+                            }
+                            if GLOBAL_STATE.srv_to_resource.is_none() {
+                                GLOBAL_STATE.srv_to_resource = Some(FnvHashMap::default());
+                            }
+                            if let Some(m) = GLOBAL_STATE.srv_to_resource.as_mut() {
+                                m.insert(srv as usize, rp);
+                            }
+                            rp
+                        }
+                    }
+                };
+                track_bound_texture(resource_ptr, stage, &mut GLOBAL_STATE);
+            }
+
+            if in_selection {
+                track_set_texture(srv as usize, stage, &mut GLOBAL_STATE);
             }
         }
     }
+    let _ = end_slot; // silence unused if checks are skipped in the future
 
     (hook_context.real_ps_set_shader_resources)(
         THIS,

--- a/Native/hook_core/src/mod_render.rs
+++ b/Native/hook_core/src/mod_render.rs
@@ -1,8 +1,55 @@
 use std::collections::HashMap;
 
-use global_state::LoadedModState;
+use fnv::FnvHashMap;
+use global_state::{LoadedModState, MAX_CHECKSUM_STAGES};
 use types::native_mod::NativeModData;
 use shared_dx::util::*;
+
+/// A snapshot of the currently bound textures used by `select` to filter
+/// candidate mods that carry texture-checksum constraints.  Keys for
+/// `checksums` are resource pointers (DX9 `IDirect3DBaseTexture9*`, DX11
+/// `ID3D11Texture2D*`).  When `checksums` is `None` or a particular bound
+/// pointer has no entry, we treat that slot as "checksum unknown", which
+/// fails any constraint on that slot.
+pub struct BoundTextures<'a> {
+    pub per_stage: [usize; MAX_CHECKSUM_STAGES],
+    pub checksums: Option<&'a FnvHashMap<usize, u32>>,
+}
+
+impl<'a> BoundTextures<'a> {
+    pub fn empty() -> Self {
+        Self { per_stage: [0usize; MAX_CHECKSUM_STAGES], checksums: None }
+    }
+}
+
+/// True iff the mod either has no texture-checksum constraint, or every
+/// slot it constrains is satisfied by the currently bound textures.
+fn checksum_constraint_matches(nmod: &NativeModData, bound: &BoundTextures) -> bool {
+    let mask = nmod.mod_data.tex_checksum_mask;
+    if mask == 0 {
+        return true;
+    }
+    for i in 0..MAX_CHECKSUM_STAGES {
+        if (mask >> i) & 1 == 0 {
+            continue;
+        }
+        let expected = nmod.mod_data.tex_checksums[i];
+        let ptr = bound.per_stage[i];
+        let actual = bound
+            .checksums
+            .and_then(|m| m.get(&ptr).copied());
+        match actual {
+            Some(a) if a == expected => {}
+            _ => return false,
+        }
+    }
+    true
+}
+
+#[inline]
+fn has_checksum_constraint(nmod: &NativeModData) -> bool {
+    nmod.mod_data.tex_checksum_mask != 0
+}
 
 fn find_parent<'a>(name:&str, mvec:&'a mut Vec<NativeModData>) -> Option<&'a mut NativeModData> {
     for p in mvec.iter_mut() {
@@ -121,24 +168,57 @@ impl<'a> std::fmt::Debug for SelectedMod<'a> {
 /// Perf note: since checking for a mod is needed for everything drawn by the game, it is better to
 /// call `preselect` first to determine if this function even needs to be called.  `select` does
 /// early out as soon as it knows there is no mod, but still incurs a bit of extra cost.
-pub fn select<'a>(mstate: &'a mut LoadedModState, prim_count:u32, vert_count:u32, current_frame_num:u64) -> Option<SelectedMod<'a>> {
+pub fn select<'a>(mstate: &'a mut LoadedModState, prim_count:u32, vert_count:u32, current_frame_num:u64, bound: &BoundTextures) -> Option<SelectedMod<'a>> {
     let mod_key = NativeModData::mod_key(vert_count, prim_count);
     let r = mstate.mods.get(&mod_key);
     // just get out of here if we didn't have a match
     r?;
 
+    // Compute which mod indices are allowed by texture-checksum constraints.
+    // Priority: if any constrained mod matches the currently bound textures,
+    // restrict selection to the matching constrained mods. Otherwise fall
+    // back to unconstrained mods (mods with `tex_checksum_mask == 0`). A
+    // constrained mod whose constraint doesn't match is never selected.
+    let (allowed, num_allowed): (Vec<bool>, usize) = {
+        let nmods = r.unwrap();
+        let mut has_match = false;
+        let mut cm: Vec<bool> = Vec::with_capacity(nmods.len());
+        for nmod in nmods.iter() {
+            let matched = has_checksum_constraint(nmod)
+                && checksum_constraint_matches(nmod, bound);
+            if matched { has_match = true; }
+            cm.push(matched);
+        }
+        let v: Vec<bool> = if has_match {
+            cm
+        } else {
+            nmods.iter().map(|nmod| !has_checksum_constraint(nmod)).collect()
+        };
+        let n = v.iter().filter(|&&b| b).count();
+        (v, n)
+    };
+    if num_allowed == 0 {
+        debug_spam!(|| format!("no allowed mods after checksum filter for {}p/{}v",
+            prim_count, vert_count));
+        return None;
+    }
+
     // found at least one mod.  do some more checks to see if each has a parent, and if the parent
     // is active.  count the active parents we find because if more than one is active,
     // we have ambiguity and can't render any of them.
-    let mut target_mod_index:usize = 0;
+    // Initialize target to the first allowed index so the n==1 and default-fallback
+    // paths refer to an allowed mod rather than nmods[0].
+    let mut target_mod_index:usize = allowed.iter().position(|&b| b).unwrap_or(0);
     let mut parent_in_mod_list = false;
     let r2 = r.and_then(|nmods| {
         let mut num_active_parents = 0;
-        let num_mods = nmods.len();
+        let num_mods = num_allowed;
         let mut observed_noparent_mods: HashMap<String,usize> = HashMap::new(); // aka the top level variants
 
-        debug_spam!(|| format!("checking {} mods for {}p/{}v", num_mods, prim_count, vert_count));
+        debug_spam!(|| format!("checking {} allowed mods (of {}) for {}p/{}v",
+            num_mods, nmods.len(), prim_count, vert_count));
         for (midx,nmod) in nmods.iter().enumerate() {
+            if !allowed[midx] { continue; }
             if nmod.parent_mod_names.is_empty() {
                 if num_mods > 1 {
                     observed_noparent_mods.insert(nmod.name.clone(), midx);
@@ -175,18 +255,16 @@ pub fn select<'a>(mstate: &'a mut LoadedModState, prim_count:u32, vert_count:u32
         match num_mods {
             0 => None,
 
-            // multiple mods but only one parent, and the parent is outside of this list, so this is a 
-            // child mod of an active parent with a different ref. that 
+            // multiple mods but only one parent, and the parent is outside of this list, so this is a
+            // child mod of an active parent with a different ref. that
             // takes precedence over whatever other variants are here.
             n if n > 1 && num_active_parents == 1 && !parent_in_mod_list => {
                 debug_spam!(|| format!("rend mod {} because just one active parent named '{}' and parent outside this list",
                     nmods[target_mod_index].name, "unknown"));
                 Some(())
             },
-            // just one mod it doesn't have a parent, or if it does and there is just one parent
-            n if n == 1 && (nmods[0].parent_mod_names.is_empty() || num_active_parents == 1) => {
-                // write_log_file(&format!("rend mod {} because just one mod with parname '{}' or {} parents",
-                // nmods[target_mod_index].name, nmods[0].parent_mod_name, num_active_parents));
+            // just one mod (allowed), it doesn't have a parent, or if it does and there is just one parent
+            n if n == 1 && (nmods[target_mod_index].parent_mod_names.is_empty() || num_active_parents == 1) => {
                 Some(())
             },
             // more than one mod, 0 or >1 active parents, so if we have a selected variant
@@ -195,7 +273,7 @@ pub fn select<'a>(mstate: &'a mut LoadedModState, prim_count:u32, vert_count:u32
                 let tmic = target_mod_index;
                 let sel_index = mstate.selected_variant.get(&mod_key).unwrap_or(&tmic);
                 debug_spam!(|| format!("var sel index: {}, max: {}", sel_index, n));
-                if *sel_index < n {
+                if *sel_index < nmods.len() && allowed.get(*sel_index).copied().unwrap_or(false) {
                     // currently child mods can't be variants - this avoids messy cases with
                     // one or more children whose parents may or may not have rendered recently.
                     nmods.get(*sel_index).and_then(|nmod| {
@@ -388,16 +466,16 @@ mod tests {
         add_mod(&mut modmap, new_mod("Mod1", 100, 200));
         add_mod(&mut modmap, new_mod("Mod2", 101, 201));
         let mut mstate = new_state(modmap);
-        let r = select(&mut mstate, 99, 100, 1);
+        let r = select(&mut mstate, 99, 100, 1, &BoundTextures::empty());
         assert!(r.is_none());
-        let r = select(&mut mstate, 100, 202, 1);
+        let r = select(&mut mstate, 100, 202, 1, &BoundTextures::empty());
         assert!(r.is_none());
-        let r = select(&mut mstate, 100, 200, 1);
+        let r = select(&mut mstate, 100, 200, 1, &BoundTextures::empty());
         match r.expect("no mod found") {
             SelectedMod::One(mod_data) => assert_eq!(mod_data.name, "mod1".to_string()),
             _ => panic!("Expected SelectedMod::One"),
         }
-        let r = select(&mut mstate, 101, 201, 1);
+        let r = select(&mut mstate, 101, 201, 1, &BoundTextures::empty());
         match r.expect("no mod found") {
             SelectedMod::One(mod_data) => assert_eq!(mod_data.name, "mod2".to_string()),
             _ => panic!("Expected SelectedMod::One"),
@@ -425,21 +503,21 @@ mod tests {
         // since both are eligible and we can't pick one
         // (note, variations doesn't apply here, because variations
         // should select root parent mods, not children).
-        let r = select(&mut mstate, 101, 201, 1);
+        let r = select(&mut mstate, 101, 201, 1, &BoundTextures::empty());
         assert!(r.is_none());
         // update so that we have just one recent parent
         let pmod = get_parent(&mut mstate, "Mod1P");
         let frame = MAX_RECENT_RENDER_PARENT_THRESH + 10; // make sure all mods are out of recent window
         pmod.last_frame_render = frame;
         // trying to select child when one parent has rendered recently should find it
-        let r = select(&mut mstate, 101, 201, frame);
+        let r = select(&mut mstate, 101, 201, frame, &BoundTextures::empty());
         assert_selected_mod_name(r, "mod2c");
         // and should not when parent hasn't been rendered
         let frame = frame + MAX_RECENT_RENDER_PARENT_THRESH + 10; // make sure all mods are out of recent window
-        let r = select(&mut mstate, 101, 201, frame);
+        let r = select(&mut mstate, 101, 201, frame, &BoundTextures::empty());
         assert!(r.is_none());
         // when a parent is rendered, its frame should update
-        let r = select(&mut mstate, 100, 200, frame+60);
+        let r = select(&mut mstate, 100, 200, frame+60, &BoundTextures::empty());
         match r {
             Some(SelectedMod::One(nmod)) => {
                 assert_eq!(nmod.name, "mod1p".to_string());
@@ -467,12 +545,12 @@ mod tests {
         let pmod = get_parent(&mut mstate, "Mod1P");
         let frame = MAX_RECENT_RENDER_PARENT_THRESH + 10; // make sure all mods are out of recent window
         pmod.last_frame_render = frame;
-        let r = select(&mut mstate, 101, 201, frame);
+        let r = select(&mut mstate, 101, 201, frame, &BoundTextures::empty());
         assert!(r.is_none());
         // and if we update our parent, we should be selected now
         let pmod = get_parent(&mut mstate, "Mod4P");
         pmod.last_frame_render = frame;
-        let r = select(&mut mstate, 101, 201, frame);
+        let r = select(&mut mstate, 101, 201, frame, &BoundTextures::empty());
         match r.expect("no mod found") {
             SelectedMod::One(mod_data) => assert_eq!(mod_data.name, "modc".to_string()),
             _ => panic!("Expected SelectedMod::One"),
@@ -497,13 +575,13 @@ mod tests {
         let mut mstate = new_state(modmap);
         // both recent = no child render.  since they are new mods their last recent frame is zero
         // (which is a bit ugly, actually it should be an option with None)
-        let r = select(&mut mstate, 101, 201, 0);
+        let r = select(&mut mstate, 101, 201, 0, &BoundTextures::empty());
         assert!(r.is_none());
         let pmod = get_parent(&mut mstate, "Mod4p");
         // advance frame to put all mods out of recent window except this one
         let frame = MAX_RECENT_RENDER_PARENT_THRESH + 10;
         pmod.last_frame_render = frame;
-        let r = select(&mut mstate, 101, 201, frame);
+        let r = select(&mut mstate, 101, 201, frame, &BoundTextures::empty());
         match r.expect("no mod found") {
             SelectedMod::One(mod_data) => assert_eq!(mod_data.name, "modc".to_string()),
             _ => panic!("Expected SelectedMod::One"),
@@ -511,7 +589,7 @@ mod tests {
         let pmod = get_parent(&mut mstate, "Mod1P");
         let frame = frame + MAX_RECENT_RENDER_PARENT_THRESH + 10;
         pmod.last_frame_render = frame;
-        let r = select(&mut mstate, 101, 201, frame);
+        let r = select(&mut mstate, 101, 201, frame, &BoundTextures::empty());
         match r.expect("no mod found") {
             SelectedMod::One(mod_data) => assert_eq!(mod_data.name, "modc".to_string()),
             _ => panic!("Expected SelectedMod::One"),
@@ -539,30 +617,30 @@ mod tests {
         let mut mstate = new_state(modmap);
         // selecting 100/200 mod should return the ModC because its parent is active - the other
         // two have no parent and so are lower priority, so we exclude them.
-        let r = select(&mut mstate, 100, 200, 0);
+        let r = select(&mut mstate, 100, 200, 0, &BoundTextures::empty());
 
         assert_selected_mod_name(r, "modc");
         // now select with a more recent frame to exclude the parent, this should return the first
         // mod, because we haven't selected a variant yet, so the default is the first
         let frame = MAX_RECENT_RENDER_PARENT_THRESH + 10;
-        let r = select(&mut mstate, 100, 200, frame);
+        let r = select(&mut mstate, 100, 200, frame, &BoundTextures::empty());
         //assert!(r.is_none(), "unexpected mod: {:?}", r.unwrap().name);
         assert_selected_mod_name(r, "mod1");
         // now pick a variant.  the indexes will be the same as the mod insertion order.
         let mk = NativeModData::mod_key(200, 100);
         mstate.selected_variant.insert(mk, 0);
-        let r = select(&mut mstate, 100, 200, frame);
+        let r = select(&mut mstate, 100, 200, frame, &BoundTextures::empty());
         assert_selected_mod_name(r, "mod1");
         *mstate.selected_variant.get_mut(&mk).expect("oops") = 1;
-        let r = select(&mut mstate, 100, 200, frame);
+        let r = select(&mut mstate, 100, 200, frame, &BoundTextures::empty());
         assert_selected_mod_name(r, "mod2");
         // select() should not return a selected child
         *mstate.selected_variant.get_mut(&mk).expect("oops") = 2;
-        let r = select(&mut mstate, 100, 200, frame);
+        let r = select(&mut mstate, 100, 200, frame, &BoundTextures::empty());
         assert!(r.is_none(), "unexpected mod");
         // select() should not puke if selected child is out of range
         *mstate.selected_variant.get_mut(&mk).expect("oops") = 3;
-        let r = select(&mut mstate, 100, 200, frame);
+        let r = select(&mut mstate, 100, 200, frame, &BoundTextures::empty());
         assert!(r.is_none(), "unexpected mod");
     }
 
@@ -602,13 +680,13 @@ mod tests {
         let frame = MAX_RECENT_RENDER_PARENT_THRESH + 10;
 
         // Cycle through variants by updating the selected_variant index.
-        let r = select(&mut mstate, 100, 200, frame);
+        let r = select(&mut mstate, 100, 200, frame, &BoundTextures::empty());
         assert_selected_mod_name(r, "variant1");
         select_next_variant(&mut mstate, frame);
-        let r = select(&mut mstate, 100, 200, frame);
+        let r = select(&mut mstate, 100, 200, frame, &BoundTextures::empty());
         assert_selected_mod_name(r, "variant2");
         select_next_variant(&mut mstate, frame);
-        let r = select(&mut mstate, 100, 200, frame);
+        let r = select(&mut mstate, 100, 200, frame, &BoundTextures::empty());
         match r {
             None => panic!("expected return for variant 3 case, got none"),
             Some(SelectedMod::One(_)) => panic!("expected many but got: {:?}", r),
@@ -619,8 +697,157 @@ mod tests {
         }
         // should wrap around
         select_next_variant(&mut mstate, frame);
-        let r = select(&mut mstate, 100, 200, frame);
+        let r = select(&mut mstate, 100, 200, frame, &BoundTextures::empty());
         assert_selected_mod_name(r, "variant1");
+    }
+
+    fn new_constrained_mod(name:&str, prims:i32, verts:i32, slot:usize, crc:u32) -> NativeModData {
+        let mut m = new_mod(name, prims, verts);
+        m.mod_data.tex_checksums[slot] = crc;
+        m.mod_data.tex_checksum_mask |= 1u8 << slot;
+        m
+    }
+
+    /// Build a BoundTextures with a single bound texture on one stage, using
+    /// a synthetic pointer and a provided checksum map.
+    fn bound_with<'a>(stage:usize, ptr:usize, cmap:&'a FnvHashMap<usize,u32>) -> BoundTextures<'a> {
+        let mut per_stage = [0usize; MAX_CHECKSUM_STAGES];
+        per_stage[stage] = ptr;
+        BoundTextures { per_stage, checksums: Some(cmap) }
+    }
+
+    #[test]
+    fn test_checksum_constrained_wins() {
+        // Two mods with same prim/vert, each constrained to a different
+        // texture checksum on stage 0. Binding texture A should pick modA,
+        // binding texture B should pick modB, binding a texture with no
+        // known checksum should pick neither.
+        let mut modmap:LoadedModsMap = new_fnv_map(4);
+        add_mod(&mut modmap, new_constrained_mod("ModA", 100, 200, 0, 0xAAAA_1111));
+        add_mod(&mut modmap, new_constrained_mod("ModB", 100, 200, 0, 0xBBBB_2222));
+        let mut mstate = new_state(modmap);
+
+        let mut cmap: FnvHashMap<usize,u32> = global_state::new_fnv_map(4);
+        cmap.insert(0xAAAA_0000usize, 0xAAAA_1111);
+        cmap.insert(0xBBBB_0000usize, 0xBBBB_2222);
+
+        let bound_a = bound_with(0, 0xAAAA_0000usize, &cmap);
+        let r = select(&mut mstate, 100, 200, 1, &bound_a);
+        assert_selected_mod_name(r, "moda");
+
+        let bound_b = bound_with(0, 0xBBBB_0000usize, &cmap);
+        let r = select(&mut mstate, 100, 200, 2, &bound_b);
+        assert_selected_mod_name(r, "modb");
+
+        // Bind a texture whose checksum isn't recorded for any candidate.
+        let unknown = bound_with(0, 0xCCCC_0000usize, &cmap);
+        let r = select(&mut mstate, 100, 200, 3, &unknown);
+        assert!(r.is_none(), "expected no mod for unknown bound texture");
+    }
+
+    #[test]
+    fn test_checksum_fallback_to_unconstrained() {
+        // Same prim/vert has one constrained mod and one unconstrained.  If
+        // the constrained mod matches the bound texture, it wins.  If not,
+        // fall through to the unconstrained one.
+        let mut modmap:LoadedModsMap = new_fnv_map(4);
+        add_mod(&mut modmap, new_constrained_mod("ModCons", 100, 200, 0, 0xDEAD_BEEF));
+        add_mod(&mut modmap, new_mod("ModUncons", 100, 200));
+        let mut mstate = new_state(modmap);
+
+        let mut cmap: FnvHashMap<usize,u32> = global_state::new_fnv_map(4);
+        cmap.insert(0x1000usize, 0xDEAD_BEEF);
+
+        // Bound texture matches the constrained mod -> constrained wins.
+        let matching = bound_with(0, 0x1000usize, &cmap);
+        let r = select(&mut mstate, 100, 200, 1, &matching);
+        assert_selected_mod_name(r, "modcons");
+
+        // Bound texture doesn't match any constrained mod -> fall back to
+        // unconstrained.  Note: the variant cycle for unconstrained needs
+        // variant selection, which isn't set; by design the first allowed
+        // (which is ModUncons) is used and it has no parent so it renders.
+        let nonmatching = bound_with(0, 0x9999usize, &cmap);
+        let r = select(&mut mstate, 100, 200, 2, &nonmatching);
+        assert_selected_mod_name(r, "moduncons");
+
+        // Empty bound state also falls back to unconstrained.
+        let r = select(&mut mstate, 100, 200, 3, &BoundTextures::empty());
+        assert_selected_mod_name(r, "moduncons");
+    }
+
+    #[test]
+    fn test_checksum_multi_stage_requires_all() {
+        // A single mod constrained on stages 0 AND 2: both must match to
+        // select.  Partial match is rejected (falls through, but with no
+        // unconstrained fallback, yields None).
+        let mut modmap:LoadedModsMap = new_fnv_map(4);
+        let mut m = new_mod("ModMulti", 100, 200);
+        m.mod_data.tex_checksums[0] = 0x1111_1111;
+        m.mod_data.tex_checksums[2] = 0x3333_3333;
+        m.mod_data.tex_checksum_mask = 0b0000_0101;
+        add_mod(&mut modmap, m);
+        let mut mstate = new_state(modmap);
+
+        let mut cmap: FnvHashMap<usize,u32> = global_state::new_fnv_map(4);
+        cmap.insert(0xA0usize, 0x1111_1111);
+        cmap.insert(0xC0usize, 0x3333_3333);
+        cmap.insert(0xBADusize, 0xDEAD_DEAD);
+
+        // Full match
+        let mut per_stage = [0usize; MAX_CHECKSUM_STAGES];
+        per_stage[0] = 0xA0;
+        per_stage[2] = 0xC0;
+        let bound = BoundTextures { per_stage, checksums: Some(&cmap) };
+        let r = select(&mut mstate, 100, 200, 1, &bound);
+        assert_selected_mod_name(r, "modmulti");
+
+        // Only stage 0 matches - should not select
+        let mut per_stage = [0usize; MAX_CHECKSUM_STAGES];
+        per_stage[0] = 0xA0;
+        per_stage[2] = 0xBAD;
+        let bound = BoundTextures { per_stage, checksums: Some(&cmap) };
+        let r = select(&mut mstate, 100, 200, 2, &bound);
+        assert!(r.is_none(), "partial checksum match should not select");
+
+        // Only stage 2 matches - should not select
+        let mut per_stage = [0usize; MAX_CHECKSUM_STAGES];
+        per_stage[0] = 0xBAD;
+        per_stage[2] = 0xC0;
+        let bound = BoundTextures { per_stage, checksums: Some(&cmap) };
+        let r = select(&mut mstate, 100, 200, 3, &bound);
+        assert!(r.is_none(), "partial checksum match should not select");
+    }
+
+    #[test]
+    fn test_checksum_missing_map_fails_constraint() {
+        // A constrained mod with no checksum map available (e.g., DX9 non-
+        // lockable pool never checksummed the texture) should not match;
+        // should fall through to unconstrained if one exists.
+        let mut modmap:LoadedModsMap = new_fnv_map(4);
+        add_mod(&mut modmap, new_constrained_mod("ModCons", 100, 200, 0, 0xDEAD_BEEF));
+        add_mod(&mut modmap, new_mod("ModUncons", 100, 200));
+        let mut mstate = new_state(modmap);
+
+        // BoundTextures::empty() has checksums=None, so any constraint fails.
+        let r = select(&mut mstate, 100, 200, 1, &BoundTextures::empty());
+        assert_selected_mod_name(r, "moduncons");
+    }
+
+    #[test]
+    fn test_checksum_all_constrained_no_match_yields_none() {
+        // All candidates are constrained and none match -> no fallback
+        // available -> None.
+        let mut modmap:LoadedModsMap = new_fnv_map(4);
+        add_mod(&mut modmap, new_constrained_mod("ModA", 100, 200, 0, 0xAAAA));
+        add_mod(&mut modmap, new_constrained_mod("ModB", 100, 200, 0, 0xBBBB));
+        let mut mstate = new_state(modmap);
+
+        let mut cmap: FnvHashMap<usize,u32> = global_state::new_fnv_map(4);
+        cmap.insert(0x10usize, 0xCCCC);
+        let bound = bound_with(0, 0x10usize, &cmap);
+        let r = select(&mut mstate, 100, 200, 1, &bound);
+        assert!(r.is_none(), "no constrained match and no unconstrained fallback => None");
     }
 
     #[test]

--- a/Native/interop/src/interop.rs
+++ b/Native/interop/src/interop.rs
@@ -5,7 +5,7 @@ use std::os::raw::c_char;
 
 
 use shared_dx::util::write_log_file;
-use global_state::HookState;
+use global_state::{HookState, GLOBAL_STATE};
 use types::interop::*;
 
 lazy_static! {
@@ -67,6 +67,49 @@ pub unsafe extern "system" fn SaveTexture(index: i32, filepath: *const u16) -> b
             write_log_file(&format!("failed to save texture: {:?}", e));
             false
         }
+    }
+}
+
+/// Look up the texture checksum for a previously-seen texture resource pointer.
+///
+/// `tex_ptr` is the native resource pointer (DX9 `IDirect3DBaseTexture9*`,
+/// DX11 `ID3D11Texture2D*`) as a `usize`.  Returns the CRC32 recorded for that
+/// texture, or `0` if no checksum is known.  Zero is treated as "unknown" by
+/// callers (real checksums of non-trivial image data collide with 0 with
+/// probability ~2^-32 and this simplifies the interop signature).
+#[allow(unused)]
+#[no_mangle]
+pub unsafe extern "system" fn GetTextureChecksum(tex_ptr: usize) -> u32 {
+    if tex_ptr == 0 {
+        return 0;
+    }
+    match GLOBAL_STATE.texture_checksums.as_ref() {
+        Some(m) => m.get(&tex_ptr).copied().unwrap_or(0),
+        None => 0,
+    }
+}
+
+/// Look up the checksum of the texture currently bound on the given stage.
+///
+/// Stages >= `MAX_CHECKSUM_STAGES` are not tracked and will always return 0.
+/// Returns 0 if nothing is bound on the stage or its checksum is unknown.
+/// Used by the snapshot code to record `TextureChecksums` in the snap meta
+/// without needing to resolve native texture pointers itself (which is
+/// especially awkward for DX11 where we need to translate SRV → resource).
+#[allow(unused)]
+#[no_mangle]
+pub unsafe extern "system" fn GetBoundTextureChecksum(stage: u32) -> u32 {
+    let s = stage as usize;
+    if s >= global_state::MAX_CHECKSUM_STAGES {
+        return 0;
+    }
+    let ptr = GLOBAL_STATE.bound_textures_per_stage[s];
+    if ptr == 0 {
+        return 0;
+    }
+    match GLOBAL_STATE.texture_checksums.as_ref() {
+        Some(m) => m.get(&ptr).copied().unwrap_or(0),
+        None => 0,
     }
 }
 

--- a/Native/types/src/interop.rs
+++ b/Native/types/src/interop.rs
@@ -75,6 +75,15 @@ pub struct ModData {
     pub _pixelShaderPath: [WCHAR; MAX_TEX_PATH_LEN], // not used
     pub mod_snap_profile: ModSnapProfile,
     pub data_available: bool,
+    /// Per-stage texture CRC32 checksum constraints. Only the slots whose
+    /// bit is set in `tex_checksum_mask` are meaningful; unused slots are 0.
+    /// When a bit is set, the mod is only rendered if the texture currently
+    /// bound on that stage has the matching checksum in
+    /// `GLOBAL_STATE.texture_checksums`. See `mod_render::select`.
+    pub tex_checksums: [u32; 4],
+    /// Bitmask over `tex_checksums` - bit `i` is set iff slot `i` is an
+    /// active constraint. 0 means "no constraint", which is the common case.
+    pub tex_checksum_mask: u8,
 }
 
 impl ModData {

--- a/Native/util/Cargo.toml
+++ b/Native/util/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 [features]
 ci = []
 
+[dependencies]
+crc32fast = "1"
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["libloaderapi", "d3d9", "d3d11", "objidlbase",
     "processthreadsapi", "memoryapi", "winerror", "winuser", "winreg",

--- a/Native/util/src/lib.rs
+++ b/Native/util/src/lib.rs
@@ -6,3 +6,4 @@ mod util;
 pub use crate::util::*;
 
 pub mod game_profile;
+pub mod tex_checksum;

--- a/Native/util/src/tex_checksum.rs
+++ b/Native/util/src/tex_checksum.rs
@@ -1,0 +1,256 @@
+//! Texture checksumming utilities used to produce a secondary key for mesh
+//! identification (see the mod_render select path).
+//!
+//! The checksum is a plain CRC32 over a fixed-size center window of the raw
+//! texture bytes at mip 0. For uncompressed formats the window is
+//! `sample_size x sample_size` pixels, centered in the image (or the whole
+//! image if it is smaller than the sample size). For block-compressed (BC)
+//! formats the window is rounded to 4-pixel block boundaries and hashed as
+//! a set of block rows.
+//!
+//! The algorithm identifier written into the snapshot meta file is
+//! `crc32-center<N>`, e.g. `crc32-center64`. Changing the algorithm later
+//! should change this identifier so existing mod yamls aren't silently
+//! invalidated.
+
+use crc32fast::Hasher;
+
+/// Default sample window, in pixels on a side.
+pub const DEFAULT_SAMPLE_SIZE: u32 = 64;
+
+/// Algorithm identifier written to the snapshot meta file.
+pub fn algorithm_name(sample_size: u32) -> String {
+    format!("crc32-center{}", sample_size)
+}
+
+/// Compute a CRC32 over the centered `sample_size x sample_size` region of an
+/// uncompressed texture surface.
+///
+/// * `data` - raw bytes of mip 0
+/// * `width`, `height` - texture dimensions in pixels
+/// * `row_pitch` - bytes per row (may exceed `width * bpp_bytes` due to padding)
+/// * `bpp_bytes` - bytes per pixel (e.g. 4 for RGBA8, 2 for R5G6B5)
+/// * `sample_size` - desired window size in pixels
+///
+/// Returns `None` if the inputs are degenerate (zero dims, too-small pitch,
+/// truncated buffer).
+pub fn compute_uncompressed(
+    data: &[u8],
+    width: u32,
+    height: u32,
+    row_pitch: u32,
+    bpp_bytes: u32,
+    sample_size: u32,
+) -> Option<u32> {
+    if width == 0 || height == 0 || bpp_bytes == 0 || sample_size == 0 {
+        return None;
+    }
+    let min_pitch = width.checked_mul(bpp_bytes)?;
+    if row_pitch < min_pitch {
+        return None;
+    }
+
+    // Clamp the window to the image size, then center it.
+    let win_w = sample_size.min(width);
+    let win_h = sample_size.min(height);
+    let x0 = (width - win_w) / 2;
+    let y0 = (height - win_h) / 2;
+
+    let row_bytes = (win_w as usize) * (bpp_bytes as usize);
+    let start_x_bytes = (x0 as usize) * (bpp_bytes as usize);
+
+    // Bounds-check the last byte we'd read.
+    let last_row = (y0 as usize) + (win_h as usize) - 1;
+    let last_byte = last_row
+        .checked_mul(row_pitch as usize)?
+        .checked_add(start_x_bytes)?
+        .checked_add(row_bytes)?;
+    if last_byte > data.len() {
+        return None;
+    }
+
+    let mut h = Hasher::new();
+    for r in 0..(win_h as usize) {
+        let row_start = ((y0 as usize) + r) * (row_pitch as usize) + start_x_bytes;
+        h.update(&data[row_start..row_start + row_bytes]);
+    }
+    Some(h.finalize())
+}
+
+/// Compute a CRC32 over the centered region of a block-compressed texture
+/// surface (BC1-BC7, i.e. DXT / BPTC). The window is rounded to 4-pixel block
+/// boundaries.
+///
+/// * `data` - raw bytes of mip 0
+/// * `width`, `height` - texture dimensions in pixels (not blocks)
+/// * `row_pitch` - bytes per row of blocks
+/// * `block_bytes` - bytes per 4x4 block (8 for BC1/BC4, 16 for BC2/BC3/BC5/BC6/BC7)
+/// * `sample_size` - desired window size in pixels
+pub fn compute_block_compressed(
+    data: &[u8],
+    width: u32,
+    height: u32,
+    row_pitch: u32,
+    block_bytes: u32,
+    sample_size: u32,
+) -> Option<u32> {
+    if width == 0 || height == 0 || block_bytes == 0 || sample_size == 0 {
+        return None;
+    }
+    // Block-compressed dims are in 4x4 blocks (rounded up).
+    let blocks_w = (width + 3) / 4;
+    let blocks_h = (height + 3) / 4;
+    let min_pitch = blocks_w.checked_mul(block_bytes)?;
+    if row_pitch < min_pitch {
+        return None;
+    }
+
+    // Window, clamped to image, rounded to blocks.
+    let win_w_px = sample_size.min(width);
+    let win_h_px = sample_size.min(height);
+    let win_w_blocks = ((win_w_px + 3) / 4).max(1);
+    let win_h_blocks = ((win_h_px + 3) / 4).max(1);
+    let win_w_blocks = win_w_blocks.min(blocks_w);
+    let win_h_blocks = win_h_blocks.min(blocks_h);
+
+    let x0_blocks = (blocks_w - win_w_blocks) / 2;
+    let y0_blocks = (blocks_h - win_h_blocks) / 2;
+
+    let row_bytes = (win_w_blocks as usize) * (block_bytes as usize);
+    let start_x_bytes = (x0_blocks as usize) * (block_bytes as usize);
+
+    let last_row = (y0_blocks as usize) + (win_h_blocks as usize) - 1;
+    let last_byte = last_row
+        .checked_mul(row_pitch as usize)?
+        .checked_add(start_x_bytes)?
+        .checked_add(row_bytes)?;
+    if last_byte > data.len() {
+        return None;
+    }
+
+    let mut h = Hasher::new();
+    for r in 0..(win_h_blocks as usize) {
+        let row_start = ((y0_blocks as usize) + r) * (row_pitch as usize) + start_x_bytes;
+        h.update(&data[row_start..row_start + row_bytes]);
+    }
+    Some(h.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_rgba8_64x64() {
+        // Build a 64x64 RGBA8 buffer with a deterministic pattern, tight pitch.
+        let w = 64u32;
+        let h = 64u32;
+        let bpp = 4u32;
+        let pitch = w * bpp;
+        let mut data = vec![0u8; (pitch * h) as usize];
+        for y in 0..h {
+            for x in 0..w {
+                let i = (y * pitch + x * bpp) as usize;
+                data[i] = (x as u8).wrapping_mul(3);
+                data[i + 1] = (y as u8).wrapping_mul(5);
+                data[i + 2] = ((x ^ y) as u8).wrapping_mul(7);
+                data[i + 3] = 0xff;
+            }
+        }
+        let a = compute_uncompressed(&data, w, h, pitch, bpp, 64).expect("hash a");
+        let b = compute_uncompressed(&data, w, h, pitch, bpp, 64).expect("hash b");
+        assert_eq!(a, b, "deterministic");
+        // Different data should produce a different hash with overwhelming probability.
+        data[0] ^= 0x01;
+        let c = compute_uncompressed(&data, w, h, pitch, bpp, 64).expect("hash c");
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn smaller_than_window_clamps() {
+        // 16x16 RGBA8, request 64 window -> should use the whole image.
+        let w = 16u32;
+        let h = 16u32;
+        let bpp = 4u32;
+        let pitch = w * bpp;
+        let mut data = vec![0u8; (pitch * h) as usize];
+        for i in 0..data.len() {
+            data[i] = i as u8;
+        }
+        let a = compute_uncompressed(&data, w, h, pitch, bpp, 64).expect("hash");
+        // Hashing with an explicit 16 window over the same image should match.
+        let b = compute_uncompressed(&data, w, h, pitch, bpp, 16).expect("hash16");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn pitch_padding_ignored() {
+        // A 4x4 RGBA8 image with 32-byte padded row pitch: hash must ignore padding.
+        let w = 4u32;
+        let h = 4u32;
+        let bpp = 4u32;
+        let tight = w * bpp; // 16
+        let padded = 32u32;
+        let mut tight_buf = vec![0u8; (tight * h) as usize];
+        let mut padded_buf = vec![0xaa_u8; (padded * h) as usize]; // fill padding with junk
+        for y in 0..h {
+            for x in 0..(tight as usize) {
+                let b = ((y as usize * 13) + x) as u8;
+                tight_buf[y as usize * tight as usize + x] = b;
+                padded_buf[y as usize * padded as usize + x] = b;
+            }
+        }
+        let a = compute_uncompressed(&tight_buf, w, h, tight, bpp, 4).expect("a");
+        let b = compute_uncompressed(&padded_buf, w, h, padded, bpp, 4).expect("b");
+        assert_eq!(a, b, "padding bytes should not affect the hash");
+    }
+
+    #[test]
+    fn rejects_truncated_buffer() {
+        let w = 64u32;
+        let h = 64u32;
+        let bpp = 4u32;
+        let pitch = w * bpp;
+        let data = vec![0u8; (pitch * (h - 1)) as usize]; // missing last row
+        assert!(compute_uncompressed(&data, w, h, pitch, bpp, 64).is_none());
+    }
+
+    #[test]
+    fn rejects_bad_inputs() {
+        let data = vec![0u8; 1024];
+        assert!(compute_uncompressed(&data, 0, 16, 64, 4, 64).is_none());
+        assert!(compute_uncompressed(&data, 16, 0, 64, 4, 64).is_none());
+        assert!(compute_uncompressed(&data, 16, 16, 0, 4, 64).is_none()); // pitch < min
+        assert!(compute_uncompressed(&data, 16, 16, 64, 0, 64).is_none());
+        assert!(compute_uncompressed(&data, 16, 16, 64, 4, 0).is_none());
+    }
+
+    #[test]
+    fn bc1_block_compressed() {
+        // 64x64 BC1: 16x16 blocks, 8 bytes each = 128 bytes per block row.
+        let w = 64u32;
+        let h = 64u32;
+        let block_bytes = 8u32;
+        let blocks_w = (w + 3) / 4;
+        let blocks_h = (h + 3) / 4;
+        let pitch = blocks_w * block_bytes;
+        let mut data = vec![0u8; (pitch * blocks_h) as usize];
+        for i in 0..data.len() {
+            data[i] = (i as u8).wrapping_mul(17);
+        }
+        let a = compute_block_compressed(&data, w, h, pitch, block_bytes, 64).expect("hash");
+        let b = compute_block_compressed(&data, w, h, pitch, block_bytes, 64).expect("hash");
+        assert_eq!(a, b);
+        // Mutating outside the center should not matter when the window is smaller
+        // than the image; here sample=64 equals image, so any change matters.
+        data[0] ^= 1;
+        let c = compute_block_compressed(&data, w, h, pitch, block_bytes, 64).expect("hash");
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn algo_name_format() {
+        assert_eq!(algorithm_name(64), "crc32-center64");
+        assert_eq!(algorithm_name(32), "crc32-center32");
+    }
+}


### PR DESCRIPTION
Adds an optional per-stage texture CRC32 checksum constraint to mods so that collisions on (vert_count, prim_count) can be disambiguated by the bound texture.  This addresses the case where two on-screen entities share the same geometry but use different textures (e.g., a character and companion wearing the same armor) where modding the mesh previously replaced both.

Native (Rust):
- New util::tex_checksum (crc32fast over a centered NxN region, default 64; handles uncompressed and BC1-BC7 block-compressed formats).
- GLOBAL_STATE gains texture_checksums, srv_to_resource, and bound_textures_per_stage[MAX_CHECKSUM_STAGES=4].
- DX9 hook_create_texture/hook_update_texture compute and cache checksums; dx9_update_texture_gc purges entries.
- DX11 hook_CreateTexture2D checksums pInitialData directly.
- DX9 SetTexture and DX11 PSSetShaderResources always track the resource pointer bound on stages 0-3 (SRV-to-resource resolution cached for DX11).
- ModData carries tex_checksums[4] + tex_checksum_mask.
- mod_render::select filters candidates: matching constrained mods win; otherwise fall back to unconstrained; new tests cover the cases.
- New interop exports GetTextureChecksum / GetBoundTextureChecksum.

Managed (F#):
- DBMod.TextureChecksums parsed from Tex[0..3]Checksum YAML hex strings.
- InteropTypes.ModData mirrors the new Tex[0..3]Checksum + TexChecksumMask fields; ModDBInterop populates them from DBMod.
- SnapMeta gains TextureChecksumAlgo + TextureChecksums; snapshot captures per-stage checksums via the new native export and writes them to the meta yaml so mod authors can copy the values into their mods.