### PR TITLE
Logging: add logOnceLazy thunk variant; use in fillModData hot loop

### DIFF
--- a/MMManaged/Logging.fs
+++ b/MMManaged/Logging.fs
@@ -98,6 +98,22 @@ module Logging =
     let logOnce(infoWarnOrError:int): logOnceFn =
         (logOnceEntry infoWarnOrError).Fn
 
+    /// Thunk-taking variant of logOnce.  The message function is only invoked
+    /// the first time the log fires, so callers in hot loops avoid paying
+    /// sprintf/%A reflection cost on every call.
+    type logOnceLazyFn = ((unit -> string) -> unit)
+    let logOnceLazy(infoWarnOrError:int): logOnceLazyFn =
+        let log = getLogger("LogOnce")
+        let called = ref false
+        fun msgFn ->
+            if not !called then
+                let msg = msgFn()
+                match infoWarnOrError with
+                | 0 -> log.Info "%s" msg
+                | 1 -> log.Warn "%s" msg
+                | _ -> log.Error "%s" msg
+                called := true
+
     let mutable private logOnceFnEntries = new Dictionary<string, LogOnceEntry>()
 
     /// After a hot-reload, mark any logOnceFn entries that have already fired as

--- a/MMManaged/ModDBInterop.fs
+++ b/MMManaged/ModDBInterop.fs
@@ -1047,8 +1047,10 @@ module ModDBInterop =
                                 | Some bvd -> bvd
                             RawBinaryWriters.rbBinormalTangent binDataLookup vertRels
 
-                    let tex1SemUnused = Logging.logOnce(0)
-                    let tex1UnormSub = Logging.logOnce(0)
+                    // lazy variants: these fire from the per-vertex hot loop, so
+                    // the message thunk avoids sprintf/%A cost on every call
+                    let tex1SemUnused = Logging.logOnceLazy(0)
+                    let tex1UnormSub = Logging.logOnceLazy(0)
                 
                     // Write part of a vertex.  The input element controls which
                     // part is written.
@@ -1117,12 +1119,13 @@ module ModDBInterop =
                                         // I don't track this data currently but write some stub bytes so the mod at least loads; if we don't
                                         // write anything the vert size check will complain about an insufficient number of bytes
                                         let stubBytes = [| byte 16; byte 128; byte 128; byte 128 |]
-                                        tex1UnormSub (
+                                        tex1UnormSub (fun () ->
                                             sprintf "warning: writing stub bytes %A for tex coord semantic index %d (format %A); no source data available" stubBytes el.SemanticIndex el.Type)
                                         bw.Write(stubBytes)
                                     | _ ->
-                                        tex1SemUnused (sprintf "warning: texture coord semantic index > 0 is ignored: index: %A; format: %A"
-                                            el.SemanticIndex el.Type)
+                                        tex1SemUnused (fun () ->
+                                            sprintf "warning: texture coord semantic index > 0 is ignored: index: %A; format: %A"
+                                                el.SemanticIndex el.Type)
                             
                             | MMVertexElemSemantic.Normal -> normalWriter modNrmIndex modVertIndex el bw
                             | MMVertexElemSemantic.Binormal


### PR DESCRIPTION
The TextureCoordinate SemanticIndex>=1 branch in fillModDataInternalHelper called tex1SemUnused/tex1UnormSub per vertex, eagerly building the warning string with sprintf "%A" on a discriminated union before passing it to logOnce. The %A reflective formatter dominated fillModData runtime (observed ~12s of a ~12.5s fill on a 16k-tri mod).

Add Logging.logOnceLazy that takes a (unit -> string) thunk so the message is only built on the first (and only) actual log emission. Switch the two hot-loop call sites to it. Other logOnce call sites are unchanged.

https://claude.ai/code/session_018nYJB8KHqc7MW7QdCDoXub