### PR TITLE
Exclude objects named EXCL_/EXCLUDE_ from mmobj export

### DIFF
--- a/BlenderScripts/io_scene_mmobj/export_mmobj.py
+++ b/BlenderScripts/io_scene_mmobj/export_mmobj.py
@@ -334,6 +334,11 @@ def write_file(filepath, objects, scene,
     # Get all meshes
     for ob_main in objects:
 
+        # skip objects flagged for exclusion by name prefix
+        if ob_main.name.startswith(("EXCL_", "EXCLUDE_")):
+            print(ob_main.name, 'is marked excluded - ignoring')
+            continue
+
         # ignore dupli children
         if ob_main.parent and ob_main.parent.dupli_type in {'VERTS', 'FACES'}:
             # XXX


### PR DESCRIPTION
Objects whose name begins with "EXCL_" or "EXCLUDE_" are now skipped during export in the Blender exporter. This lets reference geometry, helpers, and blockouts stay in the .blend scene without being written into the .mmobj file. Applies to both selection-only and whole-scene export modes, since both feed the same object loop in write_file().

https://claude.ai/code/session_019SiVcgmbunSTtZk9Phxffu