### PR TITLE
Fix MMLaunch blank-window-until-input bug via software rendering

### DIFF
--- a/MMLaunch/Program.fs
+++ b/MMLaunch/Program.fs
@@ -8,6 +8,12 @@ module Program =
         AppBuilder
             .Configure<App>()
             .UsePlatformDetect()
+            // Avalonia 11 can present a blank first frame on the GPU compositor
+            // path until the window receives input/resize (the "blank until you
+            // press Tab" bug). Software rendering composites synchronously and
+            // blits the frame, sidestepping that race; fine for this lightweight
+            // launcher UI.
+            .With(Win32PlatformOptions(RenderingMode = [| Win32RenderingMode.Software |]))
             .WithInterFont()
 
     [<STAThread>]


### PR DESCRIPTION
Since the Avalonia port, MMLaunch windows (most visibly the main launcher) intermittently render a blank first frame and only paint once an input event arrives (e.g. pressing Tab). This is the known Avalonia 11 GPU compositor first-frame present race: the window's initial composition batch is not presented until input/resize wakes the dispatcher.

Force the Win32 software renderer in buildAvaloniaApp. It composites synchronously and blits the frame, sidestepping the GPU present race, and fixes the main window and all dialogs from a single place. No meaningful downside for this lightweight launcher (simple controls plus a tiny wireframe preview).

No interop wire-protocol change, so no native code version bump.

https://claude.ai/code/session_011NaH7ygtYD6ua1R8fKrFZ1